### PR TITLE
Fixed a issue that cqerl app can't start

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -403,7 +403,7 @@ handle_info(timeout, State=#cqerl_state{checked_env=false}) ->
     ),
     Nodes = case application:get_env(cqerl, cassandra_nodes) of
         undefined -> [];
-        N -> N
+        {ok, N} -> N
     end,
     State2 = lists:foldl(fun
         (Arg, State0) -> 


### PR DESCRIPTION
The third param in lists:foldl needs to be a list http://www.erlang.org/doc/man/lists.html#foldl-3 , but application:get_env returns {ok, Val}
