### PR TITLE
Add re2 in cqerl.app.src

### DIFF
--- a/src/cqerl.app.src
+++ b/src/cqerl.app.src
@@ -11,7 +11,8 @@
   {applications, [kernel,
                   stdlib,
                   ssl,
-                  pooler]},
+                  pooler,
+                  re2]},
 
   {mod, { cqerl_app, []}},
   {env, []}


### PR DESCRIPTION
Add re2 as app dependency in cqerl.app.src. This is needed for generating releases that depend on cqerl.