### PR TITLE
Include dependencies in .app file

### DIFF
--- a/src/cqerl.app.src
+++ b/src/cqerl.app.src
@@ -12,8 +12,12 @@
                   stdlib,
                   ssl,
                   pooler,
-                  re2]},
+                  re2,
+                  semver,
+                  snappy,
+                  lz4,
+                  uuid]},
 
-  {mod, { cqerl_app, []}},
+  {mod, {cqerl_app, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
Otherwise, applications that use this one and want to generate a release will have to manually include the dependencies.