### PR TITLE
Use atoms for consistency and batch mode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,22 +174,22 @@ When performing queries, you can provide more information than just the query st
     
 3. You can tell CQErl to consider a query `reusable` or not (see below for what that means). By default, it will detect binding variables and consider it reusable if it contains (named or not) any. Queries containing *named* binding variables will be considered reusable no matter what you set `reusable` to. If you explicitely set `reusable` to `false` on a query having positional variable bindings (`?`), you would provide values with in `{Type, Value}` pairs instead of `{Key, Value}`. 
 4. You can specify how many rows you want in every result page using the `page_size` (integer) field. The devs at Cassandra recommend a value of 100 (which is the default).
-5. You can also specify what `consistency` you want the query to be executed under. Possible values include (all defined in [`include/cqerl.hrl`](include/cqerl.hrl)):
+5. You can also specify what `consistency` you want the query to be executed under. Possible values include:
 
-    * `?CQERL_CONSISTENCY_ANY`
-    * `?CQERL_CONSISTENCY_ONE`       
-    * `?CQERL_CONSISTENCY_TWO`        
-    * `?CQERL_CONSISTENCY_THREE`
-    * `?CQERL_CONSISTENCY_QUORUM`     
-    * `?CQERL_CONSISTENCY_ALL`        
-    * `?CQERL_CONSISTENCY_LOCAL_QUORUM`
-    * `?CQERL_CONSISTENCY_EACH_QUORUM`
-    * `?CQERL_CONSISTENCY_LOCAL_ONE`
+    * `any`
+    * `one`       
+    * `two`        
+    * `three`
+    * `quorum`     
+    * `all`        
+    * `local_quorum`
+    * `each_quorum`
+    * `local_one`
     
 6. In case you want to perform a [lightweight transaction][4] using `INSERT` or `UPDATE`, you can also specify the `serial_consistency` that will be use when performing it. Possible values are:
 
-    * `?CQERL_CONSISTENCY_SERIAL`
-    * `?CQERL_CONSISTENCY_LOCAL_SERIAL`
+    * `serial`
+    * `local_serial`
     
 ##### Variable bindings
 

--- a/README.md
+++ b/README.md
@@ -213,13 +213,13 @@ Special cases include:
 To perform batched queries (which can include any non-`SELECT` [DML][5] statements), simply put one or more `#cql_query{}` records in a `#cql_query_batch{}` record, and run it in place of a normal `#cql_query{}`. `#cql_query_batch{}` include the following fields:
 
 1. The `consistency` level to apply when executing the batch of queries.
-2. The `mode` of the batch, which can be `?CQERL_BATCH_LOGGED`, `?CQERL_BATCH_UNLOGGED` or `?CQERL_BATCH_COUNTER` (declared in [`include/cqerl.hrl`](include/cqerl.hrl)). Running a batch in *unlogged* mode removes the performance penalty of enforcing atomicity. The *counter* mode should be used to perform batched mutation of counter values.
+2. The `mode` of the batch, which can be `logged`, `unlogged` or `counter`. Running a batch in *unlogged* mode removes the performance penalty of enforcing atomicity. The *counter* mode should be used to perform batched mutation of counter values.
 3. Finally, you must specify the list of `queries`.
 
 ```erlang
 InsertQ = #cql_query{statement = "INSERT INTO users(id, name, password) VALUES(?, ?, ?);"},
 {ok, void} = cqerl:run_query(Client, #cql_query_batch{
-  mode=?CQERL_BATCH_UNLOGGED,
+  mode=unlogged,
   queries=[
     InsertQ#cql_query{values = [{id, new},{name, "sean"},{password, "12312"}]},
     InsertQ#cql_query{values = [{id, new},{name, "jenna"},{password, "11111"}]},

--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -30,10 +30,11 @@
     false -> inet_parse:address(Addr)
   end).
 
--type consistency_level() :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_LOCAL_ONE.
--type column_type() :: 
-  {custom, binary()} | 
-  {map, column_type(), column_type()} | 
+-type consistency_level() :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | local_one.
+-type serial_consistency() :: serial | local_serial.
+-type column_type() ::
+  {custom, binary()} |
+  {map, column_type(), column_type()} |
   {set | list, column_type()} | datatype().
 
 -type datatype() :: ascii | bigint | blob | boolean | counter | decimal | double | 
@@ -53,8 +54,8 @@
     page_size   = 100       :: integer(),
     page_state              :: binary() | undefined,
     
-    consistency = ?CQERL_CONSISTENCY_ONE :: consistency_level(),
-    serial_consistency = undefined :: ?CQERL_CONSISTENCY_SERIAL | ?CQERL_CONSISTENCY_LOCAL_SERIAL | undefined,
+    consistency = one :: consistency_level(),
+    serial_consistency = undefined :: serial_consistency() | undefined,
 
     value_encode_handler = undefined :: function() | undefined
 }).
@@ -66,8 +67,8 @@
 }).
 
 -record(cql_query_batch, {
-    consistency         = ?CQERL_CONSISTENCY_ONE :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_LOCAL_SERIAL,
     mode                = ?CQERL_BATCH_LOGGED :: ?CQERL_BATCH_LOGGED .. ?CQERL_BATCH_COUNTER,
+    consistency         = one :: consistency_level(),
     queries             = [] :: list(tuple())
 }).
 

--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -30,9 +30,15 @@
     false -> inet_parse:address(Addr)
   end).
 
+-type consistency_level_int() :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_LOCAL_SERIAL.
 -type consistency_level() :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | local_one.
+
+-type serial_consistency_int() :: ?CQERL_CONSISTENCY_SERIAL | ?CQERL_CONSISTENCY_LOCAL_SERIAL.
 -type serial_consistency() :: serial | local_serial.
+
+-type batch_mode_int() :: ?CQERL_BATCH_LOGGED | ?CQERL_BATCH_UNLOGGED | ?CQERL_BATCH_COUNTER.
 -type batch_mode() :: logged | unlogged | counter.
+
 -type column_type() ::
   {custom, binary()} |
   {map, column_type(), column_type()} |
@@ -55,8 +61,8 @@
     page_size   = 100       :: integer(),
     page_state              :: binary() | undefined,
     
-    consistency = one :: consistency_level(),
-    serial_consistency = undefined :: serial_consistency() | undefined,
+    consistency = one :: consistency_level() | consistency_level_int(),
+    serial_consistency = undefined :: serial_consistency() | serial_consistency_int() | undefined,
 
     value_encode_handler = undefined :: function() | undefined
 }).
@@ -68,8 +74,8 @@
 }).
 
 -record(cql_query_batch, {
-    consistency         = one :: consistency_level(),
-    mode                = logged :: batch_mode() | integer(),
+    consistency         = one :: consistency_level() | consistency_level_int(),
+    mode                = logged :: batch_mode() | batch_mode_int(),
     queries             = [] :: list(tuple())
 }).
 

--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -32,6 +32,7 @@
 
 -type consistency_level() :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | local_one.
 -type serial_consistency() :: serial | local_serial.
+-type batch_mode() :: logged | unlogged | counter.
 -type column_type() ::
   {custom, binary()} |
   {map, column_type(), column_type()} |
@@ -67,8 +68,8 @@
 }).
 
 -record(cql_query_batch, {
-    mode                = ?CQERL_BATCH_LOGGED :: ?CQERL_BATCH_LOGGED .. ?CQERL_BATCH_COUNTER,
     consistency         = one :: consistency_level(),
+    mode                = logged :: batch_mode() | integer(),
     queries             = [] :: list(tuple())
 }).
 

--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -30,8 +30,8 @@
     false -> inet_parse:address(Addr)
   end).
 
--type consistency_level_int() :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_LOCAL_SERIAL.
--type consistency_level() :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | local_one.
+-type consistency_level_int() :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_EACH_QUORUM | ?CQERL_CONSISTENCY_LOCAL_ONE.
+-type consistency_level() :: any | one | two | three | quorum | all | local_quorum | each_quorum | local_one.
 
 -type serial_consistency_int() :: ?CQERL_CONSISTENCY_SERIAL | ?CQERL_CONSISTENCY_LOCAL_SERIAL.
 -type serial_consistency() :: serial | local_serial.

--- a/include/cqerl_protocol.hrl
+++ b/include/cqerl_protocol.hrl
@@ -36,11 +36,11 @@
 }).
 
 -record(cqerl_query_parameters, {
-    consistency         = any :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | integer(),
+    consistency         = any :: consistency_level() | consistency_level_int(),
     skip_metadata       = false :: boolean(),
     page_state          = undefined :: binary() | undefined,
     page_size           = undefined :: integer() | undefined,
-    serial_consistency  = undefined :: serial | local_serial | undefined | integer()
+    serial_consistency  = undefined :: serial_consistency() | serial_consistency_int() | undefined
 }).
 
 -record(cqerl_query, {

--- a/include/cqerl_protocol.hrl
+++ b/include/cqerl_protocol.hrl
@@ -36,11 +36,11 @@
 }).
 
 -record(cqerl_query_parameters, {
-    consistency         = ?CQERL_CONSISTENCY_ANY :: ?CQERL_CONSISTENCY_ANY .. ?CQERL_CONSISTENCY_LOCAL_SERIAL,
+    consistency         = any :: any | one | two | three | quorum | all | local_quorum | each_quorum | serial | local_serial | integer(),
     skip_metadata       = false :: boolean(),
     page_state          = undefined :: binary() | undefined,
     page_size           = undefined :: integer() | undefined,
-    serial_consistency  = undefined :: ?CQERL_CONSISTENCY_SERIAL | ?CQERL_CONSISTENCY_LOCAL_SERIAL | undefined
+    serial_consistency  = undefined :: serial | local_serial | undefined | integer()
 }).
 
 -record(cqerl_query, {

--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -138,9 +138,9 @@ close_client(ClientRef) ->
 %% later executions of the <strong>same query</strong> to be performed faster. This parameter is <code>true</code> by default when you provide bindings in the query (positional <code>?</code>
 %% parameters or named <code>:var</code> parameters), and <code>false</code> by default when you don't. You can override the defaults.
 %%
-%% <em>Consistency</em> one of constants defined in <code>cqerl.hrl</code>, namely <code>?CQERL_CONSISTENCY_[Const]</code> where <code>Const</code> can be <code>ANY</code>, <code>ONE</code>,
-%% <code>TWO</code>, <code>THREE</code>, <code>QUORUM</code>, <code>ALL</code>, <code>LOCAL_QUORUM</code>, <code>EACH_QUORUM</code>, <code>SERIAL</code>,
-%% <code>LOCAL_SERIAL</code> or <code>LOCAL_ONE</code>.
+%% <em>Consistency</em> is represented as an atom and can be any of <code>any</code>, <code>one</code>,
+%% <code>two</code>, <code>three</code>, <code>quorum</code>, <code>all</code>, <code>local_quorum</code>, <code>each_quorum</code>, <code>serial</code>,
+%% <code>local_serial</code> or <code>local_one</code>.
 %%
 %% How <em>bindings</em> is used depends on the <em>named</em> value. <em>Named</em> is a boolean value indicating whether the parameters in the query are named parameters (<code>:var1</code>). Otherwise,
 %% they are assumed to be positional (<code>?</code>). In the first case, <em>bindings</em> is a property list (see <a href="http://www.erlang.org/doc/man/proplists.html">proplists</a>) where keys match the

--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -52,9 +52,14 @@ encode_consistency_name(quorum)       -> ?CQERL_CONSISTENCY_QUORUM;
 encode_consistency_name(all)          -> ?CQERL_CONSISTENCY_ALL;
 encode_consistency_name(local_quorum) -> ?CQERL_CONSISTENCY_LOCAL_QUORUM;
 encode_consistency_name(each_quorum)  -> ?CQERL_CONSISTENCY_EACH_QUORUM;
-encode_consistency_name(serial)       -> ?CQERL_CONSISTENCY_SERIAL;
-encode_consistency_name(local_serial) -> ?CQERL_CONSISTENCY_LOCAL_SERIAL;
 encode_consistency_name(local_one)    -> ?CQERL_CONSISTENCY_LOCAL_ONE.
+
+-spec encode_serial_consistency_name(serial_consistency() | serial_consistency_int() | undefined) -> 0 | serial_consistency_int().
+encode_serial_consistency_name(Name) when is_integer(Name) -> Name;
+encode_serial_consistency_name(undefined)    -> 0;
+encode_serial_consistency_name(serial)       -> ?CQERL_CONSISTENCY_SERIAL;
+encode_serial_consistency_name(local_serial) -> ?CQERL_CONSISTENCY_LOCAL_SERIAL.
+
 
 encode_query_parameters(#cqerl_query_parameters{consistency=Consistency,
                                                 skip_metadata=SkipMetadata,
@@ -94,7 +99,7 @@ encode_query_parameters(#cqerl_query_parameters{consistency=Consistency,
             PageStateFlag = 0
     end,
 
-    SerialConsistencyInt = encode_consistency_name(SerialConsistency),
+    SerialConsistencyInt = encode_serial_consistency_name(SerialConsistency),
     case SerialConsistencyInt of
         SerialConsistencyInt when SerialConsistencyInt == ?CQERL_CONSISTENCY_SERIAL;
                                   SerialConsistencyInt == ?CQERL_CONSISTENCY_LOCAL_SERIAL ->

--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -478,6 +478,10 @@ execute_frame(Frame=#cqerl_frame{},
                                 << QueryIDBin/binary, QueryParametersBin/binary >>).
 
 
+encode_mode_name(Mode) when is_integer(Mode) -> Mode;
+encode_mode_name(logged)   -> ?CQERL_BATCH_LOGGED;
+encode_mode_name(unlogged) -> ?CQERL_BATCH_UNLOGGED;
+encode_mode_name(counter)  -> ?CQERL_BATCH_COUNTER.
 
 
 %% @doc Given frame options and batch record (containing a set of queries), produce a
@@ -491,9 +495,10 @@ batch_frame(Frame=#cqerl_frame{}, #cql_query_batch{consistency=Consistency,
                                                    queries=Queries}) ->
     {ok, QueriesBin} = encode_batch_queries(Queries, []),
     Flags = 0,
+    TypeInt = encode_mode_name(Type),
     ConsistencyInt = encode_consistency_name(Consistency),
     request_frame(Frame#cqerl_frame{opcode=?CQERL_OP_BATCH},
-                  << Type:?CHAR, QueriesBin/binary, ConsistencyInt:?SHORT, Flags:?CHAR >>).
+                  << TypeInt:?CHAR, QueriesBin/binary, ConsistencyInt:?SHORT, Flags:?CHAR >>).
 
 
 

--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -94,10 +94,10 @@ encode_query_parameters(#cqerl_query_parameters{consistency=Consistency,
             PageStateFlag = 0
     end,
 
-    case SerialConsistency of
-        SerialConsistency when SerialConsistency == serial ;
-                               SerialConsistency == local_serial ->
-            SerialConsistencyInt = encode_consistency_name(SerialConsistency),
+    SerialConsistencyInt = encode_consistency_name(SerialConsistency),
+    case SerialConsistencyInt of
+        SerialConsistencyInt when SerialConsistencyInt == ?CQERL_CONSISTENCY_SERIAL;
+                                  SerialConsistencyInt == ?CQERL_CONSISTENCY_LOCAL_SERIAL ->
             SerialConsistencyBin = << SerialConsistencyInt:?SHORT >>,
             SerialConsistencyFlag = 1;
         _ ->

--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -42,6 +42,7 @@ encode_query_valuelist(Values) when is_list(Values) ->
     {ok, << ValuesLength:?SHORT, BytesSequence/binary >>}.
 
 
+-spec encode_consistency_name(consistency_level() | consistency_level_int()) -> consistency_level_int().
 encode_consistency_name(Name) when is_integer(Name) -> Name;
 encode_consistency_name(any)          -> ?CQERL_CONSISTENCY_ANY;
 encode_consistency_name(one)          -> ?CQERL_CONSISTENCY_ONE;
@@ -478,6 +479,7 @@ execute_frame(Frame=#cqerl_frame{},
                                 << QueryIDBin/binary, QueryParametersBin/binary >>).
 
 
+-spec encode_mode_name(batch_mode() | batch_mode_int()) -> batch_mode_int().
 encode_mode_name(Mode) when is_integer(Mode) -> Mode;
 encode_mode_name(logged)   -> ?CQERL_BATCH_LOGGED;
 encode_mode_name(unlogged) -> ?CQERL_BATCH_UNLOGGED;

--- a/test/cqerl_protocol_tests.erl
+++ b/test/cqerl_protocol_tests.erl
@@ -1,0 +1,61 @@
+-module(cqerl_protocol_tests).
+
+-import(cqerl_protocol, [query_frame/3, batch_frame/2]).
+
+-include("cqerl_protocol.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(F, #cqerl_frame{}).
+-define(Q, #cqerl_query{}).
+
+assert_query_consistency(X, Y) ->
+    ?assertEqual(
+       query_frame(?F, #cqerl_query_parameters{consistency = X}, ?Q),
+       query_frame(?F, #cqerl_query_parameters{consistency = Y}, ?Q)).
+
+assert_query_serial_consistency(X, Y) ->
+    ?assertEqual(
+       query_frame(?F, #cqerl_query_parameters{serial_consistency = X}, ?Q),
+       query_frame(?F, #cqerl_query_parameters{serial_consistency = Y}, ?Q)).
+
+assert_batch_consistency(X, Y) ->
+    ?assertEqual(
+       batch_frame(?F, #cql_query_batch{consistency = X}),
+       batch_frame(?F, #cql_query_batch{consistency = Y})).
+
+assert_batch_mode(X, Y) ->
+    ?assertEqual(
+       batch_frame(?F, #cql_query_batch{mode = X}),
+       batch_frame(?F, #cql_query_batch{mode = Y})).
+
+query_consistency_level_encoding_test() ->
+    assert_query_consistency(?CQERL_CONSISTENCY_ANY,          any),
+    assert_query_consistency(?CQERL_CONSISTENCY_ONE,          one),
+    assert_query_consistency(?CQERL_CONSISTENCY_TWO,          two),
+    assert_query_consistency(?CQERL_CONSISTENCY_THREE,        three),
+    assert_query_consistency(?CQERL_CONSISTENCY_QUORUM,       quorum),
+    assert_query_consistency(?CQERL_CONSISTENCY_ALL,          all),
+    assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_QUORUM, local_quorum),
+    assert_query_consistency(?CQERL_CONSISTENCY_EACH_QUORUM,  each_quorum),
+    assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one).
+
+query_serial_consistency_encoding_test() ->
+    assert_query_serial_consistency(0,                               undefined),
+    assert_query_serial_consistency(?CQERL_CONSISTENCY_SERIAL,       serial),
+    assert_query_serial_consistency(?CQERL_CONSISTENCY_LOCAL_SERIAL, local_serial).
+
+batch_consistency_level_encoding_test() ->
+    assert_batch_consistency(?CQERL_CONSISTENCY_ANY,          any),
+    assert_batch_consistency(?CQERL_CONSISTENCY_ONE,          one),
+    assert_batch_consistency(?CQERL_CONSISTENCY_TWO,          two),
+    assert_batch_consistency(?CQERL_CONSISTENCY_THREE,        three),
+    assert_batch_consistency(?CQERL_CONSISTENCY_QUORUM,       quorum),
+    assert_batch_consistency(?CQERL_CONSISTENCY_ALL,          all),
+    assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_QUORUM, local_quorum),
+    assert_batch_consistency(?CQERL_CONSISTENCY_EACH_QUORUM,  each_quorum),
+    assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one).
+
+batch_mode_encoding_test() ->
+    assert_batch_mode(?CQERL_BATCH_COUNTER,  counter),
+    assert_batch_mode(?CQERL_BATCH_LOGGED,   logged),
+    assert_batch_mode(?CQERL_BATCH_UNLOGGED, unlogged).

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -86,8 +86,9 @@ groups() -> [
 %%      NB: By default, we export all 1-arity user defined functions
 %%--------------------------------------------------------------------
 all() ->
-    [datatypes_test, 
-     {group, connection}, 
+    [datatypes_test,
+     protocol_test,
+     {group, connection},
      {group, database}
     ].
 
@@ -234,7 +235,10 @@ end_per_testcase(TestCase, Config) ->
 
 datatypes_test(_Config) ->
     ok = eunit:test(cqerl_datatypes).
-    
+
+protocol_test(_Config) ->
+    ok = eunit:test(cqerl_protocol).
+
 get_multiple_clients(Config, 0, Acc) -> Acc;
 get_multiple_clients(Config, N, Acc) ->
     get_multiple_clients(Config, N-1, [get_client(Config) | Acc]).


### PR DESCRIPTION
This is a simple change to the API that makes in a little cleaner IMO. In addition to the `?CQERL_CONSISTENCY_*` and `?CQERL_BATCH_*` constants, the API now accepts atoms (i.e., `any`, `one`, `two`, etc). While the API is documented as taking the atoms, it will also take the old integer values as well. This should not break any existing uses of the API, but provides a nice new option.