### PR TITLE
Fix client startup race

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -287,7 +287,7 @@ handle_call(get_any_client, From, State=#cqerl_state{clients=Clients, retrying=R
     end;
 
 handle_call(Req={get_client, Node, Opts}, From,
-            State=#cqerl_state{clients=Clients, client_stats=Stats, retrying=Retrying, globalopts=GlobalOpts, named_nodes=NamedNodes}) ->
+            State=#cqerl_state{client_stats=Stats, globalopts=GlobalOpts, named_nodes=NamedNodes}) ->
 
     NodeKey = if
         is_atom(Node) ->
@@ -300,28 +300,16 @@ handle_call(Req={get_client, Node, Opts}, From,
         error ->
             State2 = new_pool(NodeKey, Opts, GlobalOpts, State),
             case orddict:find(NodeKey, State2#cqerl_state.client_stats) of
+                error ->
+                    {reply, {closed, process_died}, State2#cqerl_state{retrying=false}};
                 {ok, #cql_client_stats{count=0}} ->
                     {reply, {error, no_available_clients}, State2#cqerl_state{retrying=false}};
                 _ ->
-                    select_client(Clients, #cql_client{node=NodeKey, busy=false, pid='_'}, From, State),
-                    {noreply, State2#cqerl_state{retrying=false}}
+                    try_select_client(#cql_client{node=NodeKey, busy=false, pid='_'}, Req, From, State2)
             end;
 
         _ ->
-            case select_client(Clients, #cql_client{node=NodeKey, busy=false, pid='_'}, From, State) of
-                no_available_clients when Retrying ->
-                    retry;
-
-                no_available_clients ->
-                    erlang:send_after(?RETRY_INITIAL_DELAY, self(), {retry, Req, From, ?RETRY_INITIAL_DELAY}),
-                    {noreply, State#cqerl_state{retrying=false}};
-
-                {existing, _, _} ->
-                    {noreply, State#cqerl_state{retrying=false}};
-
-                {new, _Pid} ->
-                    {noreply, State#cqerl_state{retrying=false}}
-            end
+            try_select_client(#cql_client{node=NodeKey, busy=false, pid='_'}, Req, From, State)
     end;
 
 handle_call(_Msg, _From, State) ->
@@ -392,12 +380,12 @@ handle_cast({client_asleep, Pid}, State=#cqerl_state{clients=Clients, client_sta
             case orddict:find(NodeKey, Stats) of
                 {ok, #cql_client_stats{min_count=Min, count=Count}} when Count =< Min ->
                     {noreply, State};
-                {ok, CStats=#cql_client_stats{count=Count}} ->
+                {ok, #cql_client_stats{}} ->
                     Pool = pool_from_node(NodeKey),
                     pooler:return_member(Pool, Pid, ok),
                     unlink(Pid),
                     ets:delete(Clients, Pid),
-                    Stats1 = orddict:store(NodeKey, CStats#cql_client_stats{count=Count-1}, Stats),
+                    Stats1 = dec_stats_count(NodeKey, Stats),
                     {noreply, State#cqerl_state{client_stats=Stats1}};
                 error ->
                     {noreply, State}
@@ -416,8 +404,7 @@ handle_info({'EXIT', From, Reason}, State=#cqerl_state{clients=Clients, client_s
     case ets:lookup(Clients, From) of
         [#cql_client{node=NodeKey}] ->
             ets:delete(Clients, From),
-            {ok, CStats=#cql_client_stats{count=Count}} = orddict:find(NodeKey, Stats),
-            {noreply, State#cqerl_state{client_stats = orddict:store(NodeKey, CStats#cql_client_stats{count = Count-1}, Stats)}};
+            {noreply, State#cqerl_state{client_stats = dec_stats_count(NodeKey, Stats)}};
         [] ->
             {stop, Reason, State}
     end;
@@ -585,12 +572,9 @@ select_client(Clients, MatchClient = #cql_client{node=Node}, User, _State) ->
         AvailableClients when length(AvailableClients) > 0 ->
             RandIdx = random:uniform(length(AvailableClients)),
             #cql_client{pid=Pid, node=NodeKey} = lists:nth(RandIdx, AvailableClients),
-            case is_process_alive(Pid) of
-                true ->
-                    cqerl_client:new_user(Pid, User),
-                    {existing, Pid, NodeKey};
-                false ->
-                    no_available_clients
+            case cqerl_client:new_user(Pid, User) of
+                ok -> {existing, Pid, NodeKey};
+                {error, _E} -> no_available_clients
             end;
 
         [] ->
@@ -603,10 +587,13 @@ select_client(Clients, MatchClient = #cql_client{node=Node}, User, _State) ->
                     no_available_clients;
 
                 Pid ->
-                    link(Pid),
                     ets:insert(Clients, #cql_client{node=Node, busy=false, pid=Pid}),
-                    cqerl_client:new_user(Pid, User),
-                    {new, Pid}
+                    case cqerl_client:new_user(Pid, User) of
+                        ok ->
+                            link(Pid),
+                            {new, Pid};
+                        {error, _E} -> no_available_clients
+                    end
             end
     end.
 
@@ -649,3 +636,27 @@ pool_from_node({ Addr, Port, Keyspace }) when is_binary(Port) ->
     pool_from_node({ Addr, binary_to_list(Port), Keyspace });
 pool_from_node(Node = { Addr, Port, Keyspace }) when is_tuple(Addr) orelse is_list(Addr), is_integer(Port), is_atom(Keyspace) ->
     binary_to_atom(base64:encode(term_to_binary(Node)), latin1).
+
+dec_stats_count(NodeKey, Stats) ->
+    case orddict:find(NodeKey, Stats) of
+        {ok, #cql_client_stats{count = 1}} -> orddict:erase(NodeKey, Stats);
+        {ok, Stat = #cql_client_stats{count = Count}} -> orddict:store(NodeKey, Stat#cql_client_stats{count=Count-1}, Stats);
+        error -> Stats
+    end.
+
+try_select_client(Client, Req, From, State = #cqerl_state{clients = Clients, retrying = Retrying}) ->
+    case select_client(Clients, Client, From, State) of
+        no_available_clients when Retrying ->
+            retry;
+
+        no_available_clients ->
+            erlang:send_after(?RETRY_INITIAL_DELAY, self(), {retry, Req, From, ?RETRY_INITIAL_DELAY}),
+            {noreply, State#cqerl_state{retrying=false}};
+
+        {existing, _, _} ->
+            {noreply, State#cqerl_state{retrying=false}};
+
+        {new, _Pid} ->
+            {noreply, State#cqerl_state{retrying=false}}
+    end.
+

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -51,7 +51,8 @@ suite() ->
 %%--------------------------------------------------------------------
 groups() -> [
     {connection, [sequence], [
-        random_selection
+        random_selection,
+        failed_connection
     ]},
     {database, [sequence], [ 
         {initial, [sequence], [connect, create_keyspace]}, 
@@ -254,6 +255,13 @@ random_selection(Config) ->
     MaxSize = proplists:get_value(pool_min_size, Config),
     MaxSize = length(DistinctPids),
     lists:foreach(fun(Client) -> cqerl:close_client(Client) end, Clients).
+
+failed_connection(Config) ->
+    {closed, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]),
+    {closed, _} = maybe_get_client([{keyspace, <<"another_fake_keyspace">>} | Config]),
+    % A previous bug would cause timeouts on subsequent calls with an already
+    % used invalid keyspace. Test that case here.
+    {closed, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]).
 
 connect(Config) ->
     {Pid, Ref} = get_client(Config),
@@ -617,19 +625,25 @@ batches_and_pages(Config) ->
     ct:log("Time elapsed inserting ~B entries and fetching in batches of ~B: ~B ms", [N, Bsz, round(timer:now_diff(now(), T1)/1000)]),
     cqerl:close_client(Client).
 
+% Call when you're expecting a valid client
 get_client(Config) ->
+    {ok, Client} = maybe_get_client(Config),
+    Client.
+
+% Call to test new_client error cases
+maybe_get_client(Config) ->
     Host = proplists:get_value(host, Config),
     SSL = proplists:get_value(prepared_ssl, Config),
     Auth = proplists:get_value(auth, Config, undefined),
     Keyspace = proplists:get_value(keyspace, Config),
     PoolMinSize = proplists:get_value(pool_min_size, Config),
     PoolMaxSize = proplists:get_value(pool_max_size, Config),
-    
+
     io:format("Options : ~w~n", [[
         {ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
         {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}
         ]]),
-        
-    {ok, Client} = cqerl:new_client(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace}, 
-                                           {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]),
-    Client.
+
+    cqerl:new_client(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace}, 
+                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
+

--- a/test/load_SUITE.erl
+++ b/test/load_SUITE.erl
@@ -20,7 +20,7 @@
 %% default data values, not perform any other operations.
 %%--------------------------------------------------------------------
 suite() -> 
-  [{timetrap, {seconds, 20}},
+  [{timetrap, {seconds, 30}},
    {require, ssl, cqerl_test_ssl},
    {require, auth, cqerl_test_auth},
    % {require, keyspace, cqerl_test_keyspace},


### PR DESCRIPTION
So this one is going to take a bit of explaining, and I don't necessarily expect you to accept it in its current form - as much as anything I just want to get some thoughts and feedback.

The initial problem I set out to solve is this: When you call `cqerl:new_client` with an invalid keyspace, you get back `{closed, {server_error, ..., ...}`, because the server booted the connection before `cqerl_client` got into the `live` state. That's fine and as it should be. What I noticed while writing some unit tests, though, is that if you call `cqerl:new_client` again with the same invalid keyspace, you'll get a `gen_server:call` timeout (and crash).

Digging into the problem, it can be traced down to the way that `cqerl:new_client` works. Most notably, it calls `cqerl_client:new_user/2` after starting the process (via `pooler`). It makes an attempt to see if the process is actually alive by calling `is_process_alive/1` at `cqerl.erl:588` but that's where the race comes in. Because this is happening just as the connection is being started (and in the case of a bad keyspace, stopping and ending) `is_process_alive/1` can return `true` but the call to `cqerl_client:new_user/2` can still end up being ignored because the process dies in that small gap. In that instance the `gen_server:call` never receives a reply.

The best solution I could come up with that didn't involve restructuring the whole FSM and startup system was to change `cqerl_client:new_user/2` to use `gen_fsm:sync_send_event/2`. This ensures that the client process has either added the new user to its `users` list or throws an `exit` exception which we can catch and handle just like was being done for `is_process_alive` returning `false`.

So that's all cool and (in combination with the other changes I've listed below) makes my tests for invalid keyspaces work fine. The catch is that it makes the overall performance of `cqerl:new_client` a bit worse than half what it was. The `many_clients` and `many_sync_clients` tests both jump on my test system from 8-9 seconds to about 20 seconds (which is why I bumped the timetrap on `load_SUITE` to 30 seconds).

And that's about where I'm at - I can't think of a clever way to get that performance back without sacrificing the correctness and consistency of the return value for `cqerl:new_client`. Frankly, even this system is not perfect since the exact error you receive still depends on the timing of the `add_user` message being sent with respect to the timing of the process shutting down.

I'd welcome any thoughts you have.

For reference, the other related changes in this PR are:

* Removed unnecessary calls to `gen_tcp:close` and `ssl:close` - owned sockets are closed anyway when the process exits, which is the only time this was being called.
* Changed the exit mode for `cqerl_client` from a crash to a `normal` exit when the server closed the connection during startup. Without this you get crash messages spamming the log and causing tests to fail when trying to test that scenario.
* Modified the stats system so that when the last client for a certain key dies that key is removed from the stats (see `dec_stats_count/2`). Otherwise certain bits of code assume that a client must still be available for that key, even if the count is 0.