### PR TITLE
Add maps:map() to valid types for #cql_query.values

### DIFF
--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -53,7 +53,7 @@
 
 -record(cql_query, {
     statement   = <<>>      :: iodata(),
-    values      = []        :: [ parameter() | named_parameter() ],
+    values      = []        :: [ parameter() | named_parameter() ] | maps:map(),
 
     reusable    = undefined :: undefined | boolean(),
     named       = false     :: boolean(),


### PR DESCRIPTION
Maps are now a valid type for query values. This change notifies dialyzer of the fact.