### PR TITLE
Empty map values and dialyzer fixes

### DIFF
--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -53,7 +53,7 @@
 
 -record(cql_query, {
     statement   = <<>>      :: iodata(),
-    values      = []        :: [ parameter() | named_parameter() ] | maps:map(),
+    values      = []        :: [ parameter() | named_parameter() ] | map(),
 
     reusable    = undefined :: undefined | boolean(),
     named       = false     :: boolean(),

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -42,7 +42,9 @@ end).
     %% Information about the connection
     inet :: any(),
     trans :: atom(),
-    socket :: gen_tcp:socket() | ssl:sslsocket(),
+    socket :: port() | ssl:sslsocket(), % The port() is actually a
+                                        % gen_tcp:socket(), but that type isn't
+                                        % currently exported (as of 18.2)
     compression_type :: undefined | snappy | lz4,
     keyspace :: atom(),
 


### PR DESCRIPTION
Couple of fixes here: First, my earlier addition of the `maps:map()` type should just have been `map()`. Also the `gen_tcp:socket()` type isn't exported, so I've changed that so that it doesn't trip dialyzer up. (I'll submit a separate patch to OTP to get that exported).

The bigger fix, though, is that empty maps weren't working as query values when there were no columns specified in a query. This change fixes that up.