### PR TITLE
Fix bug in map return type

### DIFF
--- a/src/cqerl_datatypes.erl
+++ b/src/cqerl_datatypes.erl
@@ -587,7 +587,7 @@ decode_data({{map, KeyType, ValueType}, Size, Bin}, Opts) ->
         << KSize:?INT, KeyBin:KSize/binary, VSize:?INT, ValueBin:VSize/binary >> <= EntriesBin ],
 
     case proplists:lookup(maps, Opts) of
-        {maps, trus} ->
+        {maps, true} ->
             {maps:from_list(List), Rest};
         _ ->
             {List, Rest}


### PR DESCRIPTION
When the `maps` option is set, map fields were still being returned as proplists due to a typo.