### PR TITLE
Add text_uuids option

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -212,10 +212,7 @@ size(#cql_result{dataset=Dataset}) -> length(Dataset).
 
 head(#cql_result{dataset=[]}) -> empty_dataset;
 head(Result) ->
-    case application:get_env(cqerl, maps) of
-        {ok, true} -> head(Result, [{maps, true}]);
-        _ -> head(Result, [])
-    end.
+    head(Result, get_options_list()).
 
 head(#cql_result{dataset=[Row|_Rest], columns=ColumnSpecs}, Opts) ->
     cqerl_protocol:decode_row(Row, ColumnSpecs, Opts).
@@ -239,14 +236,20 @@ next(Result) -> {head(Result), tail(Result)}.
 
 all_rows(#cql_result{dataset=[]}) -> [];
 all_rows(Result) ->
-    case application:get_env(cqerl, maps) of
-        {ok, true} -> all_rows(Result, [{maps, true}]);
-        _ -> all_rows(Result, [])
-    end.
+    all_rows(Result, get_options_list()).
 
 all_rows(#cql_result{dataset=Rows, columns=ColumnSpecs}, Opts) when is_list(Opts) ->
     [ cqerl_protocol:decode_row(Row, ColumnSpecs, Opts) || Row <- Rows ].
 
+get_options_list() ->
+    lists:foldl(fun(Option, Acc) ->
+                        case application:get_env(cqerl, Option) of
+                            {ok, true} -> [Option | Acc];
+                            _ -> Acc
+                        end
+                end,
+                [],
+                [maps, text_uuids]).
 
 %% ====================
 %% Gen_Server Callbacks

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -60,6 +60,7 @@ groups() -> [
         simple_insertion_roundtrip, 
         async_insertion_roundtrip, 
         emptiness,
+        options,
         {transactions, [parallel], [
             {types, [parallel], [
                 all_datatypes, 
@@ -516,6 +517,38 @@ custom_encoders(Config) ->
     cqerl:close_client(Client),
     ok.
 
+options(Config) ->
+    application:set_env(cqerl, maps, true),
+    application:set_env(cqerl, text_uuids, true),
+    Client = get_client(Config),
+    Cols = datatypes_columns([timeuuid, uuid]),
+    CreationQ = <<"CREATE TABLE entries2_2(",  Cols/binary, " PRIMARY KEY(col1));">>,
+    ct:log("Executing : ~s~n", [CreationQ]),
+    {ok, #cql_schema_changed{change_type=created, keyspace = <<"test_keyspace_2">>, name = <<"entries2_2">>}} =
+        cqerl:run_query(Client, CreationQ),
+
+    UUIDState = uuid:new(self()),
+    {TimeUUID, _} = uuid:get_v1(UUIDState),
+    UUID = uuid:get_v4(),
+
+    InsQ = #cql_query{statement = <<"INSERT INTO entries2_2(col1, col2) VALUES (?, ?)">>},
+    {ok, void} = cqerl:run_query(Client, InsQ#cql_query{values=RRow1=[
+        {col1, TimeUUID},
+        {col2, UUID}
+    ]}),
+
+    {ok, Result=#cql_result{}} = cqerl:run_query(Client, #cql_query{statement = <<"SELECT * FROM entries2_2;">>}),
+
+    TextTimeUUID = uuid:uuid_to_string(TimeUUID, binary_standard),
+    TextUUID = uuid:uuid_to_string(UUID, binary_standard),
+
+    [#{col1 := TextTimeUUID,
+       col2 := TextUUID}] = cqerl:all_rows(Result),
+
+    cqerl:close_client(Client),
+    application:unset_env(cqerl, maps),
+    application:unset_env(cqerl, text_uuids).
+
 collection_types(Config) ->
     Client = get_client(Config),
     
@@ -774,5 +807,5 @@ maybe_get_client(Config) ->
         ]]),
 
     cqerl:new_client(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace}, 
-                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
+                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}]).
 

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -807,5 +807,5 @@ maybe_get_client(Config) ->
         ]]),
 
     cqerl:new_client(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace}, 
-                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}]).
+                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
 


### PR DESCRIPTION
This change adds the ability to specify `text_uuids` as an application option (a la `maps`) to receive `uuid` and `timeuuid` columns as canonical-form UUID strings (in binary) rather than pure binaries.

It also cleans up some of the handling of the maps option so that future options will be able to be added more easily.