### PR TITLE
Recover from error when prepared query has been evicted

### DIFF
--- a/include/cqerl_protocol.hrl
+++ b/include/cqerl_protocol.hrl
@@ -47,8 +47,9 @@
 
 -record(cqerl_query, {
     kind                = normal :: normal | prepared,
-    statement           = <<>> :: binary(),
-    values              = [] :: list(binary())
+    statement           = <<>>   :: binary(),
+    values              = []     :: list(binary()),
+    source_query                 :: #cql_query{}
 }).
 
 -record(cqerl_result_column_spec, {
@@ -66,8 +67,7 @@
 }).
 
 -record(cqerl_cached_query, {
-    key :: term(),
-    inet :: term(),
+    key :: {pid(), binary()},
     query_ref = <<>> :: binary(),
     params_metadata :: #cqerl_result_metadata{},
     result_metadata :: #cqerl_result_metadata{}

--- a/src/cqerl_batch_sup.erl
+++ b/src/cqerl_batch_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/0]).
 
 %% Supervisor callbacks
--export([init/1, new_batch_coordinator/3]).
+-export([init/1, new_batch_coordinator/2]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I), {I, {I, start_link, []}, transient, 5000, worker, [I]}).
@@ -18,8 +18,8 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-new_batch_coordinator(Call, Inet, Batch) ->
-    supervisor:start_child(?MODULE, [{self(), Call}, Inet, Batch]).
+new_batch_coordinator(Call, Batch) ->
+    supervisor:start_child(?MODULE, [{self(), Call}, Batch]).
 
 %% ===================================================================
 %% Supervisor callbacks


### PR DESCRIPTION
Previously the evicted query error (0x2500 / 9472) would propagate back
up to the caller. That's not much use, though, because they can't force
cqerl to empty its list of prepared queries (and nor should they have
to). Instead, we now flush out the cache item and start over with it
unprepared.
For batch queries, we flush all involved queries since it's a bit fiddly
(and potentially error prone) to try to figure out which query has
failed.
I also cleaned up a few unused fields and tighted a couple of type
specs.