### PR TITLE
Prevent crashes at shutdown by cleaning up pools

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -425,6 +425,7 @@ handle_info(_Msg, State) ->
 
 
 terminate(_Reason, _State) ->
+    pooler:rm_group(cqerl),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->


### PR DESCRIPTION
At shutdown there are sometimes crashes as some code somewhere is trying to check connections into a pool that is no longer alive. Removing pools in the terminate handler resolves this issue.