### PR TITLE
Add 'hash' client allocation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ mode, set
 ```
 
 in your application config (see below). In this mode, rather than calling
-`cqerl:new_client/1`, call `cqerl:get_client/2` with the same arguments.
-Calling `cqerl:close_client/1` is *not* required in hash mode. See the comments
-at the top of `cqerl_hash.erl` for a full description of the behaviour of this
-mode.
+`cqerl:new_client/2`, call `cqerl:get_client/2` with the same arguments.
+Calling `cqerl:close_client/1` is *not* required in hash mode (but will do no
+harm). See the comments at the top of `cqerl_hash.erl` for a full description
+of the behaviour of this mode.
 
 #### All modes
 

--- a/src/cqerl_app.erl
+++ b/src/cqerl_app.erl
@@ -5,6 +5,8 @@
 %% Application callbacks
 -export([start/2, stop/1]).
 
+-export([mode/0]).
+
 %% ===================================================================
 %% Application callbacks
 %% ===================================================================
@@ -15,3 +17,6 @@ start(_StartType, _StartArgs) ->
 
 stop(_State) ->
     ok.
+
+mode() ->
+    application:get_env(cqerl, mode, pooler).

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -305,7 +305,7 @@ handle_info({ tcp_closed, _Socket }, starting, State) ->
 
 handle_info({ tcp_closed, _Socket }, live, State = #client_state{ queries = Queries }) ->
     [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
-    {stop, normal, State};
+    {stop, connection_closed, State};
 
 
 handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ socket=Socket, trans=Transport, delayed=Delayed0 }) ->

--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -38,7 +38,7 @@ init(main) ->
       }]
      }};
 
-init(Args = [key, Key = {Node, _Opts}, FullOpts, ChildCount]) ->
+init([key, Key = {Node, _Opts}, FullOpts, ChildCount]) ->
     {ok,
      {
       #{

--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -39,7 +39,6 @@ init(main) ->
      }};
 
 init(Args = [key, Key = {Node, _Opts}, FullOpts, ChildCount]) ->
-    ct:log("BJD Got start ~p", [Args]),
     {ok,
      {
       #{

--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -1,0 +1,76 @@
+-module(cqerl_client_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0,
+         add_clients/2]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+
+-define(DEFAULT_NUM_CLIENTS, 20).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, main).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init(main) ->
+    {ok,
+     {
+      #{
+       strategy => simple_one_for_one
+      },
+      [#{
+        id => key_sup,
+        start => {supervisor, start_link, [?MODULE]},
+        restart => transient,
+        type => supervisor
+      }]
+     }};
+
+init(Args = [key, Key = {Node, _Opts}, FullOpts, ChildCount]) ->
+    ct:log("BJD Got start ~p", [Args]),
+    {ok,
+     {
+      #{
+       strategy => one_for_one,
+       intensity => 5,
+       period => 10
+      },
+      [
+        client_spec(Key, Node, FullOpts, I) ||
+        I <- lists:seq(1, ChildCount)
+      ]}}.
+
+client_spec(Key, Node, FullOpts, I) ->
+    #{
+       id => {cqerl_client, Key, I},
+       start => {cqerl_client, start_link, [Node, FullOpts, Key]}
+     }.
+
+add_clients(Node, Opts) ->
+    Key = {Node, Opts},
+    ChildCount = child_count(Key),
+    GlobalOpts = cqerl:get_global_opts(),
+    OptGetter = cqerl:make_option_getter(Opts, GlobalOpts),
+    FullOpts = [ {auth, OptGetter(auth)}, {ssl, OptGetter(ssl)},
+                 {keyspace, OptGetter(keyspace)} ],
+
+    case supervisor:start_child(?MODULE, [[key, Key, FullOpts, ChildCount]]) of
+        {ok, SupPid} -> {ok, {ChildCount, SupPid}};
+        {error, E} -> {error, E}
+    end.
+
+
+child_count(_Key) ->
+    application:get_env(cqerl, num_clients, 20).

--- a/src/cqerl_hash.erl
+++ b/src/cqerl_hash.erl
@@ -1,0 +1,199 @@
+-module(cqerl_hash).
+
+-behaviour(gen_server).
+
+-export([
+    start_link/0,
+    client_started/1,
+    get_client/1
+]).
+
+-export([
+    init/1,
+    terminate/2,
+    code_change/3,
+
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-type key() :: {Node :: term(), Opts :: list()}.
+
+-record(pending, {
+          key :: key(),
+          reply_to :: [term()],
+          remaining :: non_neg_integer(),
+          sup_pid :: pid(),
+          table :: ets:tid()
+         }).
+
+-record(client_table, {
+          key :: key(),
+          sup_pid :: pid(),
+          table :: ets:tid()
+         }).
+
+-record(state, {
+          pending = [] :: [#pending{}]
+         }).
+
+start_link() ->
+    gen_server:start_link({local, cqerl}, ?MODULE, [], []).
+
+init(_) ->
+    ets:new(cqerl_client_tables, [named_table, {read_concurrency, true}, protected,
+                                  {keypos, #client_table.key}]),
+    {ok, #state{}}.
+
+client_started(Key) ->
+    gen_server:cast(cqerl, {add_client, Key, self()}).
+
+handle_call({start_clients, Key}, From, State = #state{pending = Pending}) ->
+    case ets:lookup(cqerl_client_tables, Key) of
+        [#client_table{}] ->
+            ct:log("BJD Found existing table ~p", [Key]),
+            {reply, ok, State};
+        [] ->
+            case lists:keytake(Key, #pending.key, Pending) of
+                false ->
+                    ct:log("BJD No existing table - starting clients ~p", [Key]),
+                    start_clients_impl(Key, From, State);
+                {value, PendingItem, OtherPending} ->
+                    ct:log("BJD No existing table but pending request - adding to queue ~p", [Key]),
+                    NewPending = PendingItem#pending{reply_to = [From | PendingItem#pending.reply_to]},
+                    {noreply, State#state{pending = [NewPending | OtherPending]}}
+            end
+    end;
+
+
+handle_call(_, _, State) ->
+    {noreply, State}.
+
+handle_cast({add_client, Key, Pid}, State = #state{pending = Pending}) ->
+    ct:log("BJD Got add_client for ~p / ~p", [Key, Pending]),
+    NewState =
+    case lists:keytake(Key, #pending.key, Pending) of
+        {value, PendingItem, OtherPending} ->
+            add_new_client(Pid, PendingItem, State#state{pending = OtherPending});
+        false ->
+            add_replacement_client(Key, Pid, State)
+    end,
+    {noreply, NewState};
+
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _Ref, process, Pid, Reason}, State) ->
+    NewState = clear_pending(Pid, Reason, State),
+    clear_existing(Pid),
+    {noreply, NewState};
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+get_client(Key) ->
+    NKey = normlaise_keyspace(Key),
+    case get_table(NKey) of
+        {ok, T} ->
+            N = erlang:phash2(self(), ets:info(T, size)),
+            [{_, Pid}] = ets:lookup(T, N+1),
+            {ok, {Pid, make_ref()}};
+        _ ->
+            start_clients(NKey)
+    end.
+
+start_clients(Key) ->
+    case gen_server:call(cqerl, {start_clients, Key}, infinity) of
+        ok -> get_client(Key);
+        {error, E} -> {error, E}
+    end.
+
+get_table(Key) ->
+    case ets:lookup(cqerl_client_tables, Key) of
+        [#client_table{table = T}] -> {ok, T};
+        [] -> {error, clients_not_started}
+    end.
+
+start_clients_impl({Node, Opts}, From, State) ->
+    ClientTable = ets:new(cqerl_clients, [{read_concurrency, true}, protected]),
+    case cqerl_client_sup:add_clients(Node, Opts) of
+        {error, E} -> {reply, {error, E}, State};
+        {ok, {Num, SupPid}} ->
+            monitor(process, SupPid),
+            NewPending = #pending{key = {Node, Opts}, reply_to = [From], remaining = Num, table = ClientTable, sup_pid = SupPid},
+            {noreply, State#state{pending = [NewPending  | State#state.pending]}}
+    end.
+
+add_new_client(Pid, PendingItem = #pending{reply_to = ReplyTo, key = Key, table = Table, remaining = Remaining, sup_pid = SupPid}, State = #state{pending = OtherPending}) ->
+    add_client(Pid, Table),
+    NewPending = case Remaining of
+        1 ->
+                         ct:log("BJD final client started for ~p", [Key]),
+            ets:insert(cqerl_client_tables,
+                       #client_table{
+                          key = Key,
+                          table = Table,
+                          sup_pid = SupPid}),
+            lists:foreach(fun(R) -> gen_server:reply(R, ok) end, ReplyTo),
+            OtherPending;
+        N ->
+                         ct:log("BJD client ~p started for ~p", [N, Key]),
+            [PendingItem#pending{remaining = N-1} | OtherPending]
+    end,
+    State#state{pending = NewPending}.
+
+add_replacement_client(Key, Pid, State) ->
+    {ok, T} = get_table(Key),
+    add_client(Pid, T),
+    State.
+
+add_client(Pid, Table) ->
+    monitor(process, Pid),
+    Index = find_empty_index(Table),
+    ets:insert(Table, {Index, Pid}).
+
+find_empty_index(Table) ->
+    {UsedIndices, _} = lists:unzip(ets:tab2list(Table)),
+    PossibleIndices = lists:seq(1, length(UsedIndices)+1),
+    find_empty(lists:sort(UsedIndices), PossibleIndices).
+
+find_empty([A|Tail], [A|Tail2]) -> find_empty(Tail, Tail2);
+find_empty(_, [A|_]) -> A.
+
+normlaise_keyspace({Node, Opts}) ->
+    KS = proplists:get_value(keyspace, Opts),
+    NewOpts = [{keyspace, normalise_to_atom(KS)} | proplists:delete(keyspace, Opts)],
+    {Node, NewOpts}.
+
+normalise_to_atom(KS) when is_list(KS) -> list_to_atom(KS);
+normalise_to_atom(KS) when is_binary(KS) -> binary_to_atom(KS, latin1);
+normalise_to_atom(KS) when is_atom(KS) -> KS.
+
+clear_pending(Pid, Reason, State = #state{pending = Pending}) ->
+    NewPending =
+    case lists:keytake(Pid, #pending.sup_pid, Pending) of
+        false -> Pending;
+        {value, #pending{reply_to = ReplyTo}, OtherPending} ->
+            lists:foreach(fun(R) -> gen_server:reply(R, {error, Reason}) end, ReplyTo),
+            OtherPending
+    end,
+    State#state{pending = NewPending}.
+
+clear_existing(Pid) ->
+    Tables = ets:tab2list(cqerl_client_tables),
+    lists:foreach(
+      fun(#client_table{key = K, sup_pid = SupPid, table = T}) when SupPid =:= Pid ->
+              ets:delete(cqerl_client_tables, K),
+              ets:delete(T);
+         (#client_table{table = T}) ->
+              ets:match_delete(T, {'_', Pid})
+      end,
+      Tables).

--- a/src/cqerl_sup.erl
+++ b/src/cqerl_sup.erl
@@ -24,9 +24,21 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
+    init(cqerl_app:mode());
+
+init(pooler) ->
     {ok, { {one_for_one, 5, 10}, [
       ?CHILD(cqerl, worker),
       ?CHILD(cqerl_cache, worker),
       ?CHILD(cqerl_batch_sup, supervisor),
       ?CHILD(cqerl_processor_sup, supervisor)
+    ]}};
+
+init(hash) ->
+    {ok, { {one_for_all, 5, 10}, [
+      ?CHILD(cqerl_cache, worker),
+      ?CHILD(cqerl_batch_sup, supervisor),
+      ?CHILD(cqerl_processor_sup, supervisor),
+      ?CHILD(cqerl_client_sup, supervisor),
+      ?CHILD(cqerl_hash, worker)
     ]}}.

--- a/test/hash_SUITE.erl
+++ b/test/hash_SUITE.erl
@@ -1,0 +1,202 @@
+%% common_test suite for cqerl hash mode
+
+-module(hash_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("cqerl.hrl").
+
+-compile(export_all).
+
+-import(test_helper, [
+                    %  maybe_get_client/1,
+                      get_client/1
+                     ]).
+
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%%
+%% Info = [tuple()]
+%%   List of key/value pairs.
+%%
+%% Description: Returns list of tuples to set default properties
+%%              for the suite.
+%%
+%% Note: The suite/0 function is only meant to be used to return
+%% default data values, not perform any other operations.
+%%--------------------------------------------------------------------
+suite() ->
+  [{timetrap, {seconds, 20}} | test_helper:requirements()].
+
+%%--------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%%
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%%   The name of the group.
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%%   Group properties that may be combined.
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%%   The name of a test case.
+%% Shuffle = shuffle | {shuffle,Seed}
+%%   To get cases executed in random order.
+%% Seed = {integer(),integer(),integer()}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%%   To get execution of cases repeated.
+%% N = integer() | forever
+%%
+%% Description: Returns a list of test case group definitions.
+%%--------------------------------------------------------------------
+groups() -> [
+    {clients, [sequence], [
+        create_keyspace,
+        create_clients,
+        crash_recovery,
+        outage_recovery
+    ]}
+].
+
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases
+%%
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%%   Name of a test case group.
+%% TestCase = atom()
+%%   Name of a test case.
+%%
+%% Description: Returns the list of groups and test cases that
+%%              are to be executed.
+%%
+%%      NB: By default, we export all 1-arity user defined functions
+%%--------------------------------------------------------------------
+all() ->
+    [{group, clients}
+    ].
+
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the suite.
+%%
+%% Description: Initialization before the suite.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+
+-define(KEYSPACE, "test_keyspace_3").
+
+init_per_suite(Config) ->
+    Config2 = test_helper:set_mode(hash, Config),
+    test_helper:standard_setup(?KEYSPACE, Config2).
+
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Cleanup after the suite.
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%% Reason = term()
+%%   The reason for skipping all test cases and subgroups in the group.
+%%
+%% Description: Initialization before each test case group.
+%%--------------------------------------------------------------------
+
+init_per_group(_Group, Config) ->
+    [{keyspace, "test_keyspace_3"} | Config].
+
+%%--------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%               void() | {save_config,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%%
+%% Description: Cleanup after each test case group.
+%%--------------------------------------------------------------------
+end_per_group(_group, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the test case.
+%%
+%% Description: Initialization before each test case.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config0) ->
+%%               void() | {save_config,Config1} | {fail,Reason}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for failing the test case.
+%%
+%% Description: Cleanup after each test case.
+%%--------------------------------------------------------------------
+
+create_keyspace(Config) ->
+    test_helper:create_keyspace(<<"test_keyspace_3">>, Config).
+
+create_clients(Config) ->
+    {ClientPid, _} = get_client(Config),
+    % Should get the same client pid each time:
+    {ClientPid, _} = get_client(Config),
+    % Should be two table entries (one for undefined keyspace, used to
+    % create test_keyspace_3)
+    ClientTables = ets:tab2list(cqerl_client_tables),
+    ?assertEqual(2, length(ClientTables)),
+    % Each with the default number of elements:
+    lists:foreach(fun({client_table, _, _, T}) ->
+        ?assertEqual(20, ets:info(T, size)) end,
+        ClientTables).
+
+crash_recovery(Config) ->
+    {ClientPid, _} = get_client(Config),
+    % Let's crash one:
+    exit(ClientPid, kill),
+    % Give it a second to get itself together:
+    timer:sleep(500),
+    {ClientPid2, _} = get_client(Config),
+    ?assertNotEqual(ClientPid, ClientPid2),
+    ?assert(is_process_alive(ClientPid2)).
+
+outage_recovery(_Config) ->
+    ok.

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -7,6 +7,8 @@
 
 -compile(export_all).
 
+-import(test_helper, [maybe_get_client/1, get_client/1]).
+
 %%--------------------------------------------------------------------
 %% Function: suite() -> Info
 %%
@@ -49,33 +51,52 @@ suite() ->
 %%
 %% Description: Returns a list of test case group definitions.
 %%--------------------------------------------------------------------
-groups() -> [
-    {connection, [sequence], [
-        random_selection,
-        failed_connection
-    ]},
-    {database, [sequence], [ 
-        {initial, [sequence], [connect, create_keyspace]}, 
-        create_table,
-        simple_insertion_roundtrip, 
-        async_insertion_roundtrip, 
-        emptiness,
-        missing_prepared_query,
-        missing_prepared_batch,
-        options,
-        {transactions, [parallel], [
-            {types, [parallel], [
-                all_datatypes, 
-                % custom_encoders, 
-                collection_types, 
-                counter_type,
-                varint_type,
-                decimal_type
-            ]},
-            batches_and_pages
-        ]}
-    ]}
-].
+
+connection_tests() ->
+    [
+     random_selection,
+     failed_connection
+    ].
+
+database_tests() ->
+    [
+     {initial, [sequence], [connect, create_keyspace]},
+     create_table,
+     simple_insertion_roundtrip,
+     async_insertion_roundtrip,
+     emptiness,
+     missing_prepared_query,
+     missing_prepared_batch,
+     options,
+     {transactions, [parallel],
+      [
+       {types, [parallel],
+        [
+         all_datatypes, 
+         % custom_encoders,
+         collection_types,
+         counter_type,
+         varint_type,
+         decimal_type
+        ]},
+       batches_and_pages
+      ]}
+    ].
+
+
+groups() ->
+    [
+     {pooler,
+      [
+       {connection_pooler, [sequence], connection_tests()},
+       {database_pooler, [sequence], database_tests()}
+      ]},
+     {hash,
+      [
+       {connection_hash, [sequence], connection_tests() -- [random_selection]},
+       {database_hash, [sequence], database_tests()}
+      ]}
+    ].
 
 %%--------------------------------------------------------------------
 %% Function: all() -> GroupsAndTestCases
@@ -94,8 +115,8 @@ groups() -> [
 all() ->
     [datatypes_test,
      protocol_test,
-     {group, connection},
-     {group, database}
+     {group, pooler},
+     {group, hash}
     ].
 
 %%--------------------------------------------------------------------
@@ -113,46 +134,7 @@ all() ->
 %% variable, but should NOT alter/remove any existing entries.
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    case erlang:function_exported(application, ensure_all_started, 1) of
-      true -> application:ensure_all_started(cqerl);
-      false ->
-        application:start(crypto),
-        application:start(asn1),
-        application:start(public_key),
-        application:start(ssl),
-        application:start(pooler),
-        application:start(cqerl)
-    end,
-    
-    application:start(sasl),
-    RawSSL = ct:get_config(ssl),
-    DataDir = proplists:get_value(data_dir, Config),
-    SSL = case RawSSL of
-        undefined -> false;
-        false -> false;
-        _ ->
-            %% To relative file paths for SSL, prepend the path of
-            %% the test data directory. To bypass this behavior, provide
-            %% an absolute path.
-            lists:map(fun
-                ({FileOpt, Path}) when FileOpt == cacertfile;
-                                       FileOpt == certfile;
-                                       FileOpt == keyfile ->
-                    case Path of
-                        [$/ | _Rest] -> {FileOpt, Path};
-                        _ -> {FileOpt, filename:join([DataDir, Path])}
-                    end;
-
-                (Opt) -> Opt
-            end, RawSSL)
-    end,
-    [ {auth, ct:get_config(auth)}, 
-      {ssl, RawSSL},
-      {prepared_ssl, SSL},
-      {keyspace, "test_keyspace_2"},
-      {host, ct:get_config(host)},
-      {pool_min_size, ct:get_config(pool_min_size)},
-      {pool_max_size, ct:get_config(pool_max_size)} ] ++ Config.
+    test_helper:standard_setup("test_keyspace_2", Config).
 
 %%--------------------------------------------------------------------
 %% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
@@ -182,12 +164,20 @@ end_per_suite(Config) ->
 %% Description: Initialization before each test case group.
 %%--------------------------------------------------------------------
 
-init_per_group(NoKeyspace, Config) when NoKeyspace == connection;
+init_per_group(NoKeyspace, Config) when NoKeyspace == connection_pooler;
                                         NoKeyspace == initial ->
     %% Here we remove the keyspace configuration, since we're going to drop it
     %% Otherwise, subsequent requests would sometimes fail saying that no keyspace was specified
-    [{keyspace, undefined} | Config];
-init_per_group(_group, Config) ->
+    [{keyspace, undefined} | proplists:delete(keyspace, Config)];
+
+% Move from pooler to hash mode:
+init_per_group(hash, Config) ->
+    application:stop(cqerl),
+    application:set_env(cqerl, mode, hash),
+    application:start(cqerl),
+    [{mode, hash} | Config];
+
+init_per_group(_Group, Config) ->
     Config.
 
 %%--------------------------------------------------------------------
@@ -262,11 +252,11 @@ random_selection(Config) ->
     lists:foreach(fun(Client) -> cqerl:close_client(Client) end, Clients).
 
 failed_connection(Config) ->
-    {closed, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]),
-    {closed, _} = maybe_get_client([{keyspace, <<"another_fake_keyspace">>} | Config]),
+    {error, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]),
+    {error, _} = maybe_get_client([{keyspace, <<"another_fake_keyspace">>} | Config]),
     % A previous bug would cause timeouts on subsequent calls with an already
     % used invalid keyspace. Test that case here.
-    {closed, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]).
+    {error, _} = maybe_get_client([{keyspace, <<"not_a_real_keyspace">>} | Config]).
 
 connect(Config) ->
     {Pid, Ref} = get_client(Config),
@@ -286,7 +276,7 @@ create_keyspace(Config) ->
             {ok, #cql_schema_changed{change_type=created, keyspace = <<"test_keyspace_2">>}} = cqerl:run_query(Client, Q)
     end,
     cqerl:close_client(Client).
-        
+
 create_table(Config) ->
     Client = get_client(Config),
     ct:log("Got client ~w~n", [Client]),
@@ -817,26 +807,3 @@ batches_and_pages(Config) ->
     ct:log("Time elapsed inserting ~B entries and fetching in batches of ~B: ~B ms",
            [N, Bsz, round(timer:now_diff(os:timestamp(), T1)/1000)]),
     cqerl:close_client(Client).
-
-% Call when you're expecting a valid client
-get_client(Config) ->
-    {ok, Client} = maybe_get_client(Config),
-    Client.
-
-% Call to test new_client error cases
-maybe_get_client(Config) ->
-    Host = proplists:get_value(host, Config),
-    SSL = proplists:get_value(prepared_ssl, Config),
-    Auth = proplists:get_value(auth, Config, undefined),
-    Keyspace = proplists:get_value(keyspace, Config),
-    PoolMinSize = proplists:get_value(pool_min_size, Config),
-    PoolMaxSize = proplists:get_value(pool_max_size, Config),
-
-    io:format("Options : ~w~n", [[
-        {ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
-        {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}
-        ]]),
-
-    cqerl:new_client(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace}, 
-                            {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
-

--- a/test/test_helper.erl
+++ b/test/test_helper.erl
@@ -1,0 +1,99 @@
+-module(test_helper).
+
+-include("cqerl.hrl").
+
+-export([standard_setup/2,
+         get_client/1,
+         maybe_get_client/1,
+         create_keyspace/2,
+         requirements/0,
+         set_mode/2
+        ]).
+
+
+standard_setup(Keyspace, Config) ->
+    application:ensure_all_started(cqerl),
+    application:start(sasl),
+    RawSSL = ct:get_config(ssl),
+    DataDir = proplists:get_value(data_dir, Config),
+    SSL = case RawSSL of
+        undefined -> false;
+        false -> false;
+        _ ->
+            %% To relative file paths for SSL, prepend the path of
+            %% the test data directory. To bypass this behavior, provide
+            %% an absolute path.
+            lists:map(fun
+                ({FileOpt, Path}) when FileOpt == cacertfile;
+                                       FileOpt == certfile;
+                                       FileOpt == keyfile ->
+                    case Path of
+                        [$/ | _Rest] -> {FileOpt, Path};
+                        _ -> {FileOpt, filename:join([DataDir, Path])}
+                    end;
+
+                (Opt) -> Opt
+            end, RawSSL)
+    end,
+    [ {auth, ct:get_config(auth)},
+      {ssl, RawSSL},
+      {prepared_ssl, SSL},
+      {keyspace, Keyspace},
+      {host, ct:get_config(host)},
+      {pool_min_size, ct:get_config(pool_min_size)},
+      {pool_max_size, ct:get_config(pool_max_size)} ] ++ Config.
+
+% Call when you're expecting a valid client
+get_client(Config) ->
+    {ok, Client} = maybe_get_client(Config),
+    Client.
+
+% Call to test new_client/get_client error cases
+maybe_get_client(Config) ->
+    Host = proplists:get_value(host, Config),
+    SSL = proplists:get_value(prepared_ssl, Config),
+    Auth = proplists:get_value(auth, Config, undefined),
+    Keyspace = proplists:get_value(keyspace, Config),
+    PoolMinSize = proplists:get_value(pool_min_size, Config),
+    PoolMaxSize = proplists:get_value(pool_max_size, Config),
+
+%    io:format("Options : ~w~n", [[
+%        {ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
+%        {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}
+%        ]]),
+
+    Fun = case proplists:get_value(mode, Config, pooler) of
+              pooler -> fun cqerl:new_client/2;
+              hash -> fun cqerl:get_client/2
+          end,
+
+    Fun(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
+               {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
+
+create_keyspace(KS, Config) ->
+    Client = get_client([{keyspace, undefined} | Config]),
+    Q = <<"CREATE KEYSPACE ", KS/binary, " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};">>,
+    D = <<"DROP KEYSPACE ", KS/binary>>,
+    case cqerl:run_query(Client, #cql_query{statement=Q}) of
+        {ok, #cql_schema_changed{change_type=created, keyspace = KS}} -> ok;
+        {error, {16#2400, _, {key_space, KS}}} ->
+            {ok, #cql_schema_changed{change_type=dropped, keyspace = KS}} = cqerl:run_query(Client, D),
+            {ok, #cql_schema_changed{change_type=created, keyspace = KS}} = cqerl:run_query(Client, Q)
+    end,
+    cqerl:close_client(Client).
+
+requirements() ->
+    [
+     {require, ssl, cqerl_test_ssl},
+     {require, auth, cqerl_test_auth},
+     % {require, keyspace, cqerl_test_keyspace},
+     {require, host, cqerl_host},
+     {require, pool_min_size, pool_min_size},
+     {require, pool_max_size, pool_max_size}
+    ].
+
+set_mode(Mode, Config) ->
+    application:stop(cqerl),
+    application:set_env(cqerl, mode, Mode),
+    application:start(cqerl),
+    [{mode, Mode} | proplists:delete(mode, Config)].


### PR DESCRIPTION
NOTE: This isn't intended to be merged yet - I still need to add some docs and further ct tests. The core functionality, however, is done and I figured I'd share it to get any input you (@matehat) or anyone else has before getting too far along.

A note on terminology: When I say "client" I mean a `cqerl_client` process. When I say "user" I mean any process in an application that calls `cqerl:get_client` or `cqerl:new_client` to get a client to use to make a query.

So - we've been having a few intermittent problems with the existing pooler-based implementation. Fundamentally, it doesn't seem to be an ideal choice for managing a pool of clients where each client can have multiple users, as is the case with cqerl clients. Additionally, as has been noted in #49, it has scalability issues with bottlenecks (that may not be endemic to `pooler` per se, but are certainly present in our use of it). I looked over `dispcount` as an alternative, but as I explained in my comment on #49, that doesn't seem ideal either.

What I've ended up doing, then, is to invent my own solution (which steals a couple of dispcount's neat ideas that fit our problem). Basically, for each "key" (see below), we have a set of client processes started on the first attempt to get a client using that key. Those clients, once started, are available to all users, and are allocated from a pool using a dispcount-style hash of the user's PID. Because they're multi-user clients, however, we don't need dispcount's exclusivity guarantees and so can allocate multiple users to each client.

The "key" is essentially the `NodeKey` used by the pooler implementation - a tuple of the `Node` and `Opts` used to originally set up the clients. I think this could probably stand to be simplified a bit, but for now it's what I've got. Every unique key currently starts `num_clients` (default 20) client processes - I'd also like to make that configurable on a per-keyspace basis.

Each set of clients is monitored by a `one_for_one` supervisor (call it the "set supervisor"). And these set supervisors are, in turn, monitored under a `simple_one_for_one` supervisor called `cqerl_client_sup`. What this means is that individual failures/crashes amongst a set of clients will be restarted by their set supervisor and only cause transient error conditions for any user trying to access them. If, on the other hand, the whole Cassandra server goes down (or something else equally catastrophic happens) then the clients retrying will quickly hit the set supervisor's restart intensity and cause it to shutdown too. Since `cqerl_client_sup` is a `simple_one_for_one`, however, the failure won't cascade any further upwards. Further, the next attempt by a user to access a client for that key will create a new set of clients. If they connect successfully, everything is good and we keep going. If they don't, the user (and any other uses waiting on their creation) will again receive error responses.

In addition to the set supervisor, each key has its own ets table which is used to map the hash values to a client PID. These tables are maintained by the `cqerl_hash` module/process (registered as `cqerl`) which monitors all the client processes and their immediate supervisors. They are further indexed by a "root" ets table named `cqerl_client_tables` which maps keys to their respective tables. Thus in the normal course of events, any request for a client requires two ets lookups to read-optimised tables (in much the same manner as dispcount): First to get the client table for a key, then to get the client allocated to the hash of the user process pid.

I've tried, as far as possible, to make this change backwards compatible. If you change nothing, the behaviour still uses the existing pooler system. Adding `{mode, hash}` to the cqerl app config enables the new system.

The other change required is to call `cqerl:get_client/2` rather than `cqerl:new_client`. I made that distinction mostly so that users would not accidentally end up using the wrong mode, but also because it would have required fiddly and otherwise unnecessary checks in `new_client` to have it work for both.

Calling `cqerl:close_client/1` in hash mode is not necessary, but nor is it harmful.

I've changed the integration and load tests to run in both modes, and everything seems to work okay. Load tests for hash mode are marginally (maybe ~20%) faster on my system, but it's a VM with only 2 cores - I hope on beefier machines that the improvement will be more pronounced, but I've yet to have a chance to test that.