### PR TITLE
Add support for native protocol v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Native Erlang client for CQL3 over Cassandra's binary protocol v4 (a.k.a. what y
 
 ### At a glance
 
-CQErl offers a simple Erlang interface to Cassandra using the latest CQL version (v3). The main features include:
+CQErl offers a simple Erlang interface to Cassandra using the latest CQL version. The main features include:
 
 * Automatic (and configurable) connection pools using [pooler][1]
 * Batched queries
@@ -324,9 +324,9 @@ Just include this repository in your project's `rebar.config` file and run `./re
 
 ### Compatibility
 
-As said earlier, this library uses Cassandra's newest native protocol version (2), which is said to perform better than the older Thrift-based interface. It also speaks CQL version 3, and uses new features available in Cassandra 2.X, such as paging, parametrization, query preparation and so on.
+As said earlier, this library uses Cassandra's newest native protocol versions (v4, or v3 [optionally](#connecting-to-older-cassandra-instances)), which is said to perform better than the older Thrift-based interface. It also speaks CQL version 3, and uses new features available in Cassandra 2.X, such as paging, parametrization, query preparation and so on.
 
-All this means is that this library works with Cassandra 2.X, configured to enable the native protocol. [This documentation page][8] gives details about the how to configure this protocol. In the `cassandra.yaml` configuration file of your Cassandra installation, the `start_native_transport` need to be set to true and you need to take note of the value for `native_transport_port`, which is the port used by this library.
+All this means is that this library works with Cassandra 2.1.x (2.2+ or 3+ recommended), configured to enable the native protocol. [This documentation page][8] gives details about the how to configure this protocol. In the `cassandra.yaml` configuration file of your Cassandra installation, the `start_native_transport` need to be set to true and you need to take note of the value for `native_transport_port`, which is the port used by this library.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ of the behaviour of this mode.
 
 1. The first argument to `cqerl:get_client/2`, `cqerl:new_client/2` or `cqerl_new_client/1` is the node to which you wish to connect as `{Ip, Port}`. If empty, it defaults to `{"127.0.0.1", 9042}`, and `Ip` can be given as a string, or as a tuple of components, either IPv4 or IPv6.
 
-2. The second possible argument (when using `cqerl:get_client/2` or `cqerl:new_client/2`) is a list of options, that include `auth` (mentionned below), `ssl` (which is `false` by default, but can be set to a list of SSL options) and `keyspace` (string or binary). Other options include `pool_max_size`, `pool_min_size` and `pool_cull_interval`, which are used to configure [pooler][1] (see its documentation to understand those options).
+2. The second possible argument (when using `cqerl:get_client/2` or `cqerl:new_client/2`) is a list of options, that include `auth` (mentionned below), `ssl` (which is `false` by default, but can be set to a list of SSL options) and `keyspace` (string or binary). Other options include `pool_max_size`, `pool_min_size`, and `pool_cull_interval` which are used to configure [pooler][1] (see its documentation to understand those options), and `protocol_version` to [connect to older Cassandra instances](#connecting-to-older-cassandra-instances).
 
 If you've set simple username/password authentication scheme on Cassandra, you can provide those to CQErl
 
@@ -298,6 +298,25 @@ varchar               | **binary**, string
 varint                | **integer** (arbitrary precision)
 timeuuid              | **binary**, `now`
 inet                  | `{X1, X2, X3, X4}` (IPv4), `{Y1, Y2, Y3, Y4, Y5, Y6, Y7, Y8}` (IPv6), string or binary
+
+### Connecting to older Cassandra instances
+
+By default, this client library assumes we're talking to a 2.2+ or 3+ instance of Cassandra. 2.1.x the latest native protocol (v4) which is required to use some of the newest datatypes and optimizations. To tell CQErl to use the older protocol version (v3), which is required to connect to a 2.1.x instance of Cassandra, you can set the `protocol_version` option to the integer `3`, in your configuration file, i.e.
+
+```erlang
+[
+  {cqerl, [
+            {cassandra_nodes, [ { "127.0.0.1", 9042 } ]},
+            {protocol_version, 3}
+          ]},
+]
+```
+
+or in a `cqerl:new_client/2` or `cqerl:get_client/2` call
+
+```erlang
+{ok, Client} = cqerl:new_client("127.0.0.1:9042", [{protocol_version, 3}, {keyspace, oper}]).
+```
 
 ### Installation
 

--- a/include/cqerl.hrl
+++ b/include/cqerl.hrl
@@ -28,6 +28,8 @@
     is_reference(element(2, Client))
 ).
 
+-define(DEFAULT_PROTOCOL_VERSION, 4).
+
 -define(CQERL_PARSE_ADDR (Addr), case erlang:function_exported(inet, parse_address, 1) of
     true -> inet:parse_address(Addr);
     false -> inet_parse:address(Addr)

--- a/include/cqerl_protocol.hrl
+++ b/include/cqerl_protocol.hrl
@@ -1,8 +1,9 @@
 -ifndef(_CQERL_PROTOCOL_HRL_).
 -define(_CQERL_PROTOCOL_HRL_, 1).
 
--define(CQERL_FRAME_RESP,         16#84).
--define(CQERL_FRAME_REQ,          16#04).
+-define(MIN_CQERL_FRAME_RESP,     16#83).
+-define(MAX_CQERL_FRAME_RESP,     16#84).
+-define(CQERL_FRAME_REQ,          16#00).
 -define(CQERL_FRAME_COMPRESSION,  16#01).
 -define(CQERL_FRAME_TRACING,      16#02).
 

--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -63,7 +63,7 @@ add_clients(Node, Opts) ->
     GlobalOpts = cqerl:get_global_opts(),
     OptGetter = cqerl:make_option_getter(Opts, GlobalOpts),
     FullOpts = [ {auth, OptGetter(auth)}, {ssl, OptGetter(ssl)},
-                 {keyspace, OptGetter(keyspace)} ],
+                 {keyspace, OptGetter(keyspace)}, {protocol_version, OptGetter(protocol_version)} ],
 
     case supervisor:start_child(?MODULE, [[key, Key, FullOpts, ChildCount]]) of
         {ok, SupPid} -> {ok, {ChildCount, SupPid}};

--- a/src/cqerl_processor.erl
+++ b/src/cqerl_processor.erl
@@ -3,13 +3,14 @@
 
 -define(INT,   32/big-signed-integer).
 
--export([start_link/3, process/3]).
+-export([start_link/4, process/4]).
 
-start_link(ClientPid, UserQuery, Msg) ->
-    Pid = spawn_link(?MODULE, process, [ClientPid, UserQuery, Msg]),
+start_link(ClientPid, UserQuery, Msg, ProtocolVersion) ->
+    Pid = spawn_link(?MODULE, process, [ClientPid, UserQuery, Msg, ProtocolVersion]),
     {ok, Pid}.
 
-process(ClientPid, A, B) ->
+process(ClientPid, A, B, ProtocolVersion) ->
+    cqerl:put_protocol_version(ProtocolVersion),
     try do_process(ClientPid, A, B) of
         Result -> Result
     catch

--- a/src/cqerl_processor_sup.erl
+++ b/src/cqerl_processor_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/0]).
 
 %% Supervisor callbacks
--export([init/1, new_processor/2]).
+-export([init/1, new_processor/3]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I), {I, {I, start_link, []}, transient, 5000, worker, [I]}).
@@ -18,8 +18,8 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-new_processor(UserQuery, Msg) ->
-    supervisor:start_child(?MODULE, [self(), UserQuery, Msg]).
+new_processor(UserQuery, Msg, ProtocolVersion) ->
+    supervisor:start_child(?MODULE, [self(), UserQuery, Msg, ProtocolVersion]).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/test/integrity_SUITE.erl
+++ b/test/integrity_SUITE.erl
@@ -521,7 +521,7 @@ all_datatypes(Config) ->
                 ({col16, {Y, M, D}}) ->
                     {Y, M, D} = proplists:get_value(col16, Row);
 
-                ({col17, _}) -> proplists:get_value(col17, Row) == AbsTime;
+                ({col18, _}) -> proplists:get_value(col18, Row) == AbsTime;
 
                 ({col1, Key}) when is_list(Key) ->
                     Val = list_to_binary(Key),

--- a/test/test.config
+++ b/test/test.config
@@ -8,5 +8,7 @@
 
 {cqerl_test_keyspace, "test_keyspace"}.
 {cqerl_host, { "127.0.0.1", 9042 }}.
+{cqerl_protocol_version, 3}.
+
 {pool_min_size, 5}.
 {pool_max_size, 10}.

--- a/test/test.config
+++ b/test/test.config
@@ -8,7 +8,7 @@
 
 {cqerl_test_keyspace, "test_keyspace"}.
 {cqerl_host, { "127.0.0.1", 9042 }}.
-{cqerl_protocol_version, 3}.
+{cqerl_protocol_version, 4}.
 
 {pool_min_size, 5}.
 {pool_max_size, 10}.

--- a/test/test_helper.erl
+++ b/test/test_helper.erl
@@ -41,7 +41,8 @@ standard_setup(Keyspace, Config) ->
       {keyspace, Keyspace},
       {host, ct:get_config(host)},
       {pool_min_size, ct:get_config(pool_min_size)},
-      {pool_max_size, ct:get_config(pool_max_size)} ] ++ Config.
+      {pool_max_size, ct:get_config(pool_max_size)},
+      {protocol_version, ct:get_config(protocol_version)} ] ++ Config.
 
 % Call when you're expecting a valid client
 get_client(Config) ->
@@ -56,6 +57,8 @@ maybe_get_client(Config) ->
     Keyspace = proplists:get_value(keyspace, Config),
     PoolMinSize = proplists:get_value(pool_min_size, Config),
     PoolMaxSize = proplists:get_value(pool_max_size, Config),
+    ProtocolVersion = proplists:get_value(protocol_version, Config),
+
 
 %    io:format("Options : ~w~n", [[
 %        {ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
@@ -68,7 +71,8 @@ maybe_get_client(Config) ->
           end,
 
     Fun(Host, [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
-               {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize} ]).
+               {pool_min_size, PoolMinSize}, {pool_max_size, PoolMaxSize}, 
+               {protocol_version, ProtocolVersion} ]).
 
 create_keyspace(KS, Config) ->
     Client = get_client([{keyspace, undefined} | Config]),
@@ -85,6 +89,7 @@ create_keyspace(KS, Config) ->
 requirements() ->
     [
      {require, ssl, cqerl_test_ssl},
+     {require, protocol_version, cqerl_protocol_version},
      {require, auth, cqerl_test_auth},
      % {require, keyspace, cqerl_test_keyspace},
      {require, host, cqerl_host},


### PR DESCRIPTION
Fix #63

@bernardd what do you think?

Basically, this means that to use this client library with a 2.1.x Cassandra instance, one needs to set the `protocol_version` application parameter to `3`, or provide it in the client options.