### PR TITLE
v1.0 pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,40 +25,36 @@ CQErl was designed to be as simple as possible on your side. You just provide th
 
 ### Usage
 
-#### Pooler Mode
-This is the default/original mode. It uses [pooler][1] to manage connections, and
-has been around for quite a while, so is reasonably well tested. It does,
-however, have a couple of performance bottlenecks that may limit scalability on
-larger or more heaviliy loaded systems.
-
 ##### Connecting
 
 If you installed cassandra and didn't change any configuration related to authentication or SSL, you should be able to connect like this
 
 ```erlang
-{ok, Client} = cqerl:new_client({}).
+{ok, Client} = cqerl:get_client({}).
 ```
 
-And close the connection like this
+You do not need to close the connection after you've finished using it.
+
+#### Legacy Mode (pooler)
+
+The default mode of operation uses a hash of the user process's PID to allocate
+clients, in a similar way to the system used by [dispcount][9]. 
+
+The old mode used [pooler][1] to manage connections, and
+has been around for quite a while, so is reasonably well tested. It does,
+however, have a couple of performance bottlenecks that may limit scalability on
+larger or more heaviliy loaded systems.
+
+To use the old mode, and be able to use the legacy `new_client/0,1,2` API to get a hold of a
+client process, set
 
 ```erlang
-cqerl:close_client(Client).
-```
-
-#### Hash Mode
-Hash mode is a new mode which uses a hash of the user process's PID to allocate
-clients, in a similar way to the system used by [dispcount][9]. To enable this
-mode, set
-
-```erlang
-{mode, hash}
+{mode, pooler}
 ```
 
 in your application config (see below). In this mode, rather than calling
-`cqerl:new_client/2`, call `cqerl:get_client/2` with the same arguments.
-Calling `cqerl:close_client/1` is *not* required in hash mode (but will do no
-harm). See the comments at the top of `cqerl_hash.erl` for a full description
-of the behaviour of this mode.
+`cqerl:get_client/2`, call `cqerl:new_client/2` with the same arguments.
+Calling `cqerl:close_client/1` *is* required in legacy mode.
 
 #### All modes
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Native Erlang client for CQL3 over Cassandra's latest binary protocol v4.
 CQErl offers a simple Erlang interface to Cassandra using the latest CQL version. The main features include:
 
 * Automatic connection pooling, with hash-based allocation (a la [dispcount][9])
+* Single or multi-cluster support
 * Batched queries
 * Variable bindings in CQL queries (named or positional)
 * Automatic query reuse when including variable bindings

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Native Erlang client for CQL3 over Cassandra's latest binary protocol v4.
 
-[**Usage**](#usage) &middot; [Connecting](#connecting) &middot; [Performing queries](#performing-queries) &middot; [Query options](#providing-options-along-queries) &middot; [Batched queries](#batched-queries) &middot; [Reusable queries](#reusable-queries) &middot; [Data types](#data-types)
+[**Usage**](#usage) &middot; [Connecting](#connecting) &middot; [Clusters](#clusters) &middot; [Performing queries](#performing-queries) &middot; [Query options](#providing-options-along-queries) &middot; [Batched queries](#batched-queries) &middot; [Reusable queries](#reusable-queries) &middot; [Data types](#data-types)
 
 [**Installation**](#installation) &middot; [**Compatibility**](#compatibility) &middot; [**Tests**](#tests) &middot; [**License**](#license)
 
@@ -87,7 +87,7 @@ Calling `cqerl:close_client/1` *is* required in legacy mode.
     1. `cqerl:get_client()` if you have just a single main cluster
     2. `cqerl:get_client(ClusterKey)` if you want to get a client from a specific, identified cluster
 
-###### Using environment variables
+#### Using environment variables
 
 All the options given above can be provided as environment variables, in which case they are used as default (and overridable) values to any `cqerl:get_client` calls. You can also provide a `cassandra_nodes` variable containing a list of the tuples used as the first argument to `cqerl:get_client` (see [clusters](#clusters) for more explanations). So for example, in your `app.config` or `sys.config` file, you could have the following content:
 
@@ -102,6 +102,88 @@ All the options given above can be provided as environment variables, in which c
 ```
 
 Doing so will fire up connection pools as soon as the CQErl application is started. So when later on you call `cqerl:get_client`, chances are you will hit a preallocated connection (unless they're so busy that CQErl needs to fire up new ones). In fact, if you provide the `cassandra_nodes` environment variable, you can call `cqerl:get_client/0`, which chooses an available client at random.
+
+#### Clusters
+
+With CQErl clusters, you can configure either a single set of cassandra nodes from which you can draw a client at any time, or multiple sets that serve different purposes.
+
+##### Single cluster
+
+You can prepare a single cluster setup using this structure in your sys.config file:
+
+```erlang
+[
+  {cqerl, [ {cassandra_nodes, [ 
+                % You can use any of the forms below to specify a cassandra node
+                { "127.0.0.1", 9042 },
+                { {127, 0, 0, 2}, 9042 },
+                "127.0.0.3"
+            ]},
+            { keyspace, dev_keyspace }
+          ]},
+]
+```
+
+or, equivalently, there's an API you can use to add nodes to the single main cluster:
+
+```erlang
+cqerl_cluster:add_nodes([
+    { "127.0.0.1", 9042},
+    { {127, 0, 0, 2}, 9042 },
+    "127.0.0.3"
+]).
+```
+
+or, with connection options:
+
+```erlang
+cqerl_cluster:add_nodes([
+    { "127.0.0.1", 9042},
+    { {127, 0, 0, 2}, 9042 },
+    "127.0.0.3"
+], [
+    { keyspace, dev_keyspace }
+]).
+```
+
+When your main cluster is configured, you can just use `cqerl:get_client/0` to get a client random from the cluster.
+
+##### Multiple clusters
+
+You can prepare multiple clusters using this structure in your sys.config file:
+
+```erlang
+[
+  {cqerl, [ {cassandra_clusters, [
+                { config, {
+                    [ "127.0.0.1", "127.0.0.3" ], 
+                    [ { keyspace, config } ] 
+                }},
+                { operations, {
+                    [ "127.0.0.1:9042", {"127.0.0.1", 9042} ], 
+                    [ { keyspace, operations } ] 
+                }}
+            ]},
+          ]},
+]
+```
+
+or, equivalently, there's an API you can use to add nodes to particular clusters:
+
+```erlang
+cqerl_cluster:add_nodes(config, [
+    { "127.0.0.1", 9042},
+    "127.0.0.3"
+], [
+    { keyspace, config }
+]).
+cqerl_cluster:add_nodes(operations, [
+    { "127.0.0.1", 9042},
+    "127.0.0.3"
+], [
+    { keyspace, operations }
+]).
+```
 
 ##### Options
 
@@ -312,87 +394,6 @@ varint                | **integer** (arbitrary precision)
 timeuuid              | **binary**, `now`
 inet                  | `{X1, X2, X3, X4}` (IPv4), `{Y1, Y2, Y3, Y4, Y5, Y6, Y7, Y8}` (IPv6), string or binary
 
-### Clusters
-
-With CQErl clusters, you can configure either a single set of cassandra nodes from which you can draw a client at any time, or multiple sets that serve different purposes.
-
-##### Single cluster
-
-You can prepare a single cluster setup using this structure in your sys.config file:
-
-```erlang
-[
-  {cqerl, [ {cassandra_nodes, [ 
-                % You can use any of the forms below to specify a cassandra node
-                { "127.0.0.1", 9042 },
-                { {127, 0, 0, 2}, 9042 },
-                "127.0.0.3"
-            ]},
-            { keyspace, dev_keyspace }
-          ]},
-]
-```
-
-or, equivalently, there's an API you can use to add nodes to the single main cluster:
-
-```erlang
-cqerl_cluster:add_nodes([
-    { "127.0.0.1", 9042},
-    { {127, 0, 0, 2}, 9042 },
-    "127.0.0.3"
-]).
-```
-
-or, with connection options:
-
-```erlang
-cqerl_cluster:add_nodes([
-    { "127.0.0.1", 9042},
-    { {127, 0, 0, 2}, 9042 },
-    "127.0.0.3"
-], [
-    { keyspace, dev_keyspace }
-]).
-```
-
-When your main cluster is configured, you can just use `cqerl:get_client/0` to get a client random from the cluster.
-
-##### Multiple clusters
-
-You can prepare multiple clusters using this structure in your sys.config file:
-
-```erlang
-[
-  {cqerl, [ {cassandra_clusters, [
-                { config, {
-                    [ "127.0.0.1", "127.0.0.3" ], 
-                    [ { keyspace, config } ] 
-                }},
-                { operations, {
-                    [ "127.0.0.1:9042", {"127.0.0.1", 9042} ], 
-                    [ { keyspace, operations } ] 
-                }}
-            ]},
-          ]},
-]
-```
-
-or, equivalently, there's an API you can use to add nodes to particular clusters:
-
-```erlang
-cqerl_cluster:add_nodes(config, [
-    { "127.0.0.1", 9042},
-    "127.0.0.3"
-], [
-    { keyspace, config }
-]).
-cqerl_cluster:add_nodes(operations, [
-    { "127.0.0.1", 9042},
-    "127.0.0.3"
-], [
-    { keyspace, operations }
-]).
-```
 
 ### Connecting to older Cassandra instances
 

--- a/README.md
+++ b/README.md
@@ -364,14 +364,14 @@ You can prepare multiple clusters using this structure in your sys.config file:
 ```erlang
 [
   {cqerl, [ {cassandra_clusters, [
-                { config, 
-                    [ { "127.0.0.1", 9042 }, "127.0.0.3" ], 
+                { config, {
+                    [ "127.0.0.1", "127.0.0.3" ], 
                     [ { keyspace, config } ] 
-                },
-                { operations, 
-                    [ { "127.0.0.1", 9042 }, "127.0.0.3" ], 
+                }},
+                { operations, {
+                    [ "127.0.0.1:9042", {"127.0.0.1", 9042} ], 
                     [ { keyspace, operations } ] 
-                }
+                }}
             ]},
           ]},
 ]

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ Native Erlang client for CQL3 over Cassandra's latest binary protocol v4.
 
 CQErl offers a simple Erlang interface to Cassandra using the latest CQL version. The main features include:
 
-* Automatic (and configurable) connection pools using [pooler][1]
+* Automatic connection pooling, with hash-based allocation (a la [dispcount][9])
 * Batched queries
-* Variable bindings in CQL queries (named or not)
+* Variable bindings in CQL queries (named or positional)
 * Automatic query reuse when including variable bindings
-* Collection types support
+* Collection type support
+* User-defined type support
 * Tunable consistency level
 * Synchronous or asynchronous queries
 * Automatic compression (using lz4 or snappy if available)
 * SSL support
 * Pluggable authentication (as long as it's [SASL][2]-based)
 
-CQErl was designed to be as simple as possible on your side. You just provide the configuration you want as environment variables, and ask for a new client everytime you need to perform a transient piece of work (e.g. handle a web request). You do not need to (and should not) keep a client in state for a long time. Under the hood, CQErl maintains a pool of persistent connections with Cassandra and this pattern is the best way to ensure proper load balancing of requests across the pool.
+CQErl was designed to be as simple as possible on your side. You just provide the configuration you want as environment variables, and ask to get a client everytime you need to perform a transient piece of work (e.g. handle a web request). You do not need to (and in fact *should not*) keep a client in state for a long time. Under the hood, CQErl maintains a pool of persistent connections with Cassandra and this pattern is the best way to ensure proper load balancing of requests across the pool.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ Calling `cqerl:close_client/1` *is* required in legacy mode.
 
 1. The first argument to `cqerl:get_client/2`, `cqerl:new_client/2` or `cqerl_new_client/1` is the node to which you wish to connect as `{Ip, Port}`. If empty, it defaults to `{"127.0.0.1", 9042}`, and `Ip` can be given as a string, or as a tuple of components, either IPv4 or IPv6.
 
-2. The second possible argument (when using `cqerl:get_client/2` or `cqerl:new_client/2`) is a list of options, that include `auth` (mentionned below), `ssl` (which is `false` by default, but can be set to a list of SSL options) and `keyspace` (string or binary). Other options include `pool_max_size`, `pool_min_size`, and `pool_cull_interval` which are used to configure [pooler][1] (see its documentation to understand those options), and `protocol_version` to [connect to older Cassandra instances](#connecting-to-older-cassandra-instances).
+    If the default port is used, you can provide just the IP address as the first argument, either as a tuple, list or binary.
+
+2. The second possible argument (when using `cqerl:get_client/2` or `cqerl:new_client/2`) is a list of options, that include:
+
+    - `auth` (mentionned below)
+    - `ssl` (which is `false` by default, but can be set to a list of SSL options) and `keyspace` (string or binary). 
+    - `protocol_version` to [connect to older Cassandra instances](#connecting-to-older-cassandra-instances).
+
+    Other options include `pool_max_size`, `pool_min_size`, and `pool_cull_interval` which are used to configure [pooler][1] (see its documentation to understand those options)
 
 If you've set simple username/password authentication scheme on Cassandra, you can provide those to CQErl
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Calling `cqerl:close_client/1` *is* required in legacy mode.
 
 2. The second possible argument (when using `cqerl:get_client/2` or `cqerl:new_client/2`) is a list of options, that include:
 
+    - `keyspace` which determines in which keyspace all subsequent requests operate, on that connection.
     - `auth` (mentionned below)
     - `ssl` (which is `false` by default, but can be set to a list of SSL options) and `keyspace` (string or binary). 
     - `protocol_version` to [connect to older Cassandra instances](#connecting-to-older-cassandra-instances).

--- a/src/cqerl.app.src
+++ b/src/cqerl.app.src
@@ -1,7 +1,7 @@
 {application, cqerl,
  [
   {description, "CQErl client for Cassandra"},
-  {vsn, "0.9.0"},
+  {vsn, "1.0.0"},
 
   {registered, [cqerl,
                 cqerl_sup,

--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -39,7 +39,9 @@
     get_client/2,
     
     get_global_opts/0,
-    make_option_getter/2
+    make_option_getter/2,
+
+    prepare_node_info/1
 ]).
 
 -export([
@@ -60,11 +62,12 @@
 
 -opaque client() :: {pid(), reference()}.
 
--type inet() :: { inet:ip_address() | string(), Port :: integer() }.
+-type inet() :: { inet:ip_address() | string(), Port :: integer() } | inet:ip_address() | string() | binary() | {}.
 
 -export_type([client/0, inet/0]).
 
 -define(SEED, {erlang:unique_integer([positive]), erlang:unique_integer([positive]), erlang:unique_integer([positive])}).
+-define(IPV4_RE, <<"^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})(?::([0-9]{1,5}))?$">>).
 
 -record(cql_client_stats, {
     min_count :: integer(),
@@ -92,6 +95,7 @@
 -define(RETRY_EXP_FACT, 1.15).
 
 -define(DEFAULT_PORT, 9042).
+-define(LOCALHOST, "127.0.0.1").
 
 -spec prepare_client(Inet :: inet(), Opts :: list(tuple() | atom())) -> ok.
 prepare_client(Inet, Opts) ->
@@ -127,12 +131,18 @@ new_client(Inet, Opts) ->
 get_client() ->
     cqerl_cluster:get_any_client().
 
--spec get_client(ClusterKey :: atom()) -> {ok, client()} | {error, term()}.
-get_client(ClusterKey) ->
-    cqerl_cluster:get_any_client(ClusterKey).
+-spec get_client(ClusterKeyOrInet :: atom() | inet()) -> {ok, client()} | {error, term()}.
 
-% Use in `hash' mode
--spec get_client(Inet :: inet() | {}, Opts :: list(tuple() | atom())) -> {ok, client()} | {error, term()}.
+get_client(ClusterKey) when is_atom(ClusterKey) ->
+    cqerl_cluster:get_any_client(ClusterKey);
+
+get_client({}) ->
+    cqerl_hash:get_client({prepare_node_info({?LOCALHOST, ?DEFAULT_PORT}), []});
+
+get_client(Spec) ->
+    cqerl_hash:get_client({prepare_node_info(Spec), []}).
+
+-spec get_client(Inet :: inet(), Opts :: list(tuple() | atom())) -> {ok, client()} | {error, term()}.
 get_client(Spec, Opts) ->
     cqerl_hash:get_client({prepare_node_info(Spec), Opts}).
 
@@ -645,10 +655,30 @@ prepare_node_info({TupleAddr, Port}) when is_tuple(TupleAddr) andalso erlang:siz
     {TupleAddr, Port};
 
 prepare_node_info(Addr) when is_atom(Addr);
-                             is_list(Addr);
                              is_tuple(Addr) andalso erlang:size(Addr) == 4;    % v4
                              is_tuple(Addr) andalso erlang:size(Addr) == 8 ->  % v6
-    prepare_node_info({Addr, ?DEFAULT_PORT}).
+    prepare_node_info({Addr, ?DEFAULT_PORT});
+
+prepare_node_info(Addr) when is_binary(Addr) ->
+    case re2:match(Addr, ?IPV4_RE) of
+        {match, [_, IP, <<>>]} ->
+            prepare_node_info({binary_to_list(IP), ?DEFAULT_PORT});
+        {match, [_, IP, Port]} ->
+            {PortInt, []} = string:to_integer(binary_to_list(Port)),
+            prepare_node_info({binary_to_list(IP), PortInt});
+        nomatch ->
+            prepare_node_info({binary_to_list(Addr), ?DEFAULT_PORT})
+    end;
+prepare_node_info(Addr) when is_list(Addr) ->
+    case re2:match(Addr, ?IPV4_RE) of
+        {match, [_, IP, <<>>]} ->
+            prepare_node_info({binary_to_list(IP), ?DEFAULT_PORT});
+        {match, [_, IP, Port]} ->
+            {PortInt, []} = string:to_integer(binary_to_list(Port)),
+            prepare_node_info({binary_to_list(IP), PortInt});
+        nomatch ->
+            prepare_node_info({Addr, ?DEFAULT_PORT})
+    end.
 
 -spec pool_from_node(Node :: {inet:ip_address() | string(), integer() | string() | binary(), atom()}) -> atom().
 

--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -34,7 +34,10 @@
 
     start_link/0,
 
+    get_client/0,
+    get_client/1,
     get_client/2,
+    
     get_global_opts/0,
     make_option_getter/2
 ]).
@@ -115,6 +118,18 @@ new_client({}, Opts) ->
 new_client(Inet, Opts) ->
     gen_server:call(?MODULE, {get_client, prepare_node_info(Inet), Opts}).
 
+
+
+
+% Use in `hash' mode
+
+-spec get_client() -> {ok, client()} | {error, term()}.
+get_client() ->
+    cqerl_cluster:get_any_client().
+
+-spec get_client(ClusterKey :: atom()) -> {ok, client()} | {error, term()}.
+get_client(ClusterKey) ->
+    cqerl_cluster:get_any_client(ClusterKey).
 
 % Use in `hash' mode
 -spec get_client(Inet :: inet() | {}, Opts :: list(tuple() | atom())) -> {ok, client()} | {error, term()}.

--- a/src/cqerl_app.erl
+++ b/src/cqerl_app.erl
@@ -12,11 +12,11 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    application:start(pooler),
+    application:start(hash),
     cqerl_sup:start_link().
 
 stop(_State) ->
     ok.
 
 mode() ->
-    application:get_env(cqerl, mode, pooler).
+    application:get_env(cqerl, mode, hash).

--- a/src/cqerl_app.erl
+++ b/src/cqerl_app.erl
@@ -12,7 +12,7 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    application:start(hash),
+    application:ensure_all_started(pooler),
     cqerl_sup:start_link().
 
 stop(_State) ->

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -12,12 +12,13 @@
 
 -export([
 	start_link/0,
+
 	get_any_client/1,
 	get_any_client/0,
-    add_clients/1,
-    add_clients/2,
-    add_clients_to_cluster/2,
-    add_clients_to_cluster/3
+
+    add_nodes/1,
+    add_nodes/2,
+    add_nodes/3
 ]).
 
 -define (PRIMARY_CLUSTER, '$primary_cluster').
@@ -30,17 +31,17 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-add_clients(ClientKeys) ->
+add_nodes(ClientKeys) ->
     gen_server:cast(?MODULE, {add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}).
 
-add_clients(ClientKeys, Opts) when is_list(ClientKeys) ->
-    add_clients_to_cluster(?PRIMARY_CLUSTER, ClientKeys, Opts).
+add_nodes(ClientKeys, Opts) when is_list(ClientKeys) ->
+    add_nodes(?PRIMARY_CLUSTER, ClientKeys, Opts);
 
-add_clients_to_cluster(Key, ClientKeys) when is_atom(Key) ->
+add_nodes(Key, ClientKeys) when is_atom(Key) ->
     gen_server:cast(?MODULE, {add_to_cluster, Key, ClientKeys}).
 
-add_clients_to_cluster(Key, ClientKeys, Opts0) ->
-	add_clients_to_cluster(Key, lists:map(fun
+add_nodes(Key, ClientKeys, Opts0) ->
+	add_nodes(Key, lists:map(fun
 		({Inet, Opts}) when is_list(Opts) ->
 			{Inet, Opts ++ Opts0};
 		(Inet) ->

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -1,0 +1,107 @@
+-module (cqerl_cluster).
+
+-export([
+    init/1,
+    terminate/2,
+    code_change/3,
+
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-export([
+	start_link/0,
+	get_any_from_cluster/1,
+	get_any/0,
+    add_clients_to_cluster/2,
+    add_clients_to_cluster/3
+]).
+
+-define (PRIMARY_CLUSTER, '$primary_cluster').
+
+-record(cluster_table, {
+          key :: cqerl_hash:key(),
+          client_key :: cqerl_hash:key()
+         }).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+add_clients_to_cluster(Key, ClientKeys) ->
+    gen_server:cast(?MODULE, {add_to_cluster, Key, ClientKeys}).
+
+add_clients_to_cluster(Key, ClientKeys, Opts0) ->
+	add_clients_to_cluster(Key, lists:map(fun
+		({Inet, Opts}) when is_list(Opts) ->
+			{Inet, Opts ++ Opts0};
+		(Inet) ->
+			{Inet, Opts0}
+	end, ClientKeys)).
+
+get_any_from_cluster(Key) ->
+	case ets:lookup(cqerl_clusters, Key) of
+		[] -> {error, cluster_not_configured};
+		Nodes ->
+			Table = lists:nth(random:uniform(length(Nodes)), Nodes),
+			cqerl_hash:get_client(Table#cluster_table.client_key)
+	end.
+
+get_any() ->
+	get_any_from_cluster(?PRIMARY_CLUSTER).
+
+init(_) ->
+    ets:new(cqerl_clusters, [named_table, {read_concurrency, true}, protected, 
+                             {keypos, #cluster_table.key}, bag]),
+    {ok, undefined, 0}.
+
+handle_cast({add_to_cluster, ClusterKey, ClientKeys}, _State) ->
+	Tables = ets:lookup(cqerl_clusters, ClusterKey),
+    AlreadyStarted = sets:from_list(lists:map(fun
+    	(#cluster_table{client_key=ClientKey}) -> ClientKey
+    end, Tables)),
+    NewClients = sets:subtract(sets:from_list(ClientKeys), AlreadyStarted),
+    lists:map(fun
+        (Key) -> 
+        	case cqerl_hash:get_client(Key) of
+        		{ok, _} ->
+        			ets:insert(cqerl_clusters, #cluster_table{key=ClusterKey, client_key=Key});
+        		{error, Reason} ->
+        			io:format(standard_error, "Error while starting client ~p for cluster ~p:~n~p", [Key, ClusterKey, Reason])
+        	end
+    end, sets:to_list(NewClients)),
+    {noreply, undefined}.
+
+handle_info(timeout, _State) ->
+	case application:get_env(cqerl, cassandra_clusters, undefined) of
+    	undefined ->
+    		case application:get_env(cqerl, cassandra_nodes, undefined) of
+    			undefined -> ok;
+    			ClientKeys when is_list(ClientKeys) ->
+    				handle_cast({add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}, undefined)
+    		end;
+
+    	Clusters when is_map(Clusters) ->
+    		maps:map(fun
+    			({ClusterKey, {ClientKeys, Opts0}}) when is_list(ClientKeys) ->
+    				handle_cast({add_to_cluster, ClusterKey, lists:map(fun
+						({Inet, Opts}) when is_list(Opts) ->
+							{Inet, Opts ++ Opts0};
+						(Inet) ->
+							{Inet, Opts0}
+					end, ClientKeys)}, undefined);
+
+				({ClusterKey, ClientKeys}) when is_list(ClientKeys) ->
+    				handle_cast({add_to_cluster, ClusterKey, ClientKeys}, undefined)
+    		end, Clusters)
+    end,
+    {noreply, undefined};
+
+handle_info(_Msg, _State) -> {noreply, undefined}.
+
+handle_call(_Msg, _From, _State) -> {reply, {error, unexpected_message}, undefined}.
+
+code_change(_OldVsn, _State, _Extra) -> {ok, undefined}.
+
+terminate(_Reason, _State) ->
+	ok.

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -14,6 +14,8 @@
 	start_link/0,
 	get_any_from_cluster/1,
 	get_any/0,
+    add_clients/1,
+    add_clients/2,
     add_clients_to_cluster/2,
     add_clients_to_cluster/3
 ]).
@@ -28,7 +30,13 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-add_clients_to_cluster(Key, ClientKeys) ->
+add_clients(ClientKeys) ->
+    gen_server:cast(?MODULE, {add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}).
+
+add_clients(ClientKeys, Opts) when is_list(ClientKeys) ->
+    add_clients_to_cluster(?PRIMARY_CLUSTER, ClientKeys, Opts).
+
+add_clients_to_cluster(Key, ClientKeys) when is_atom(Key) ->
     gen_server:cast(?MODULE, {add_to_cluster, Key, ClientKeys}).
 
 add_clients_to_cluster(Key, ClientKeys, Opts0) ->

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -64,7 +64,7 @@ init(_) ->
                              {keypos, #cluster_table.key}, bag]),
     {ok, undefined, 0}.
 
-handle_cast({add_to_cluster, ClusterKey, ClientKeys}, _State) ->
+handle_cast({add_to_cluster, ClusterKey, ClientKeys}, State) ->
 	Tables = ets:lookup(cqerl_clusters, ClusterKey),
     AlreadyStarted = sets:from_list(lists:map(fun
     	(#cluster_table{client_key=ClientKey}) -> ClientKey
@@ -79,9 +79,9 @@ handle_cast({add_to_cluster, ClusterKey, ClientKeys}, _State) ->
         			io:format(standard_error, "Error while starting client ~p for cluster ~p:~n~p", [Key, ClusterKey, Reason])
         	end
     end, sets:to_list(NewClients)),
-    {noreply, undefined}.
+    {noreply, State}.
 
-handle_info(timeout, _State) ->
+handle_info(timeout, State) ->
 	case application:get_env(cqerl, cassandra_clusters, undefined) of
     	undefined ->
     		case application:get_env(cqerl, cassandra_nodes, undefined) of
@@ -104,13 +104,16 @@ handle_info(timeout, _State) ->
     				handle_cast({add_to_cluster, ClusterKey, ClientKeys}, undefined)
     		end, Clusters)
     end,
-    {noreply, undefined};
+    {noreply, State};
 
-handle_info(_Msg, _State) -> {noreply, undefined}.
+handle_info(_Msg, State) -> 
+    {noreply, State}.
 
-handle_call(_Msg, _From, _State) -> {reply, {error, unexpected_message}, undefined}.
+handle_call(_Msg, _From, State) -> 
+    {reply, {error, unexpected_message}, State}.
 
-code_change(_OldVsn, _State, _Extra) -> {ok, undefined}.
+code_change(_OldVsn, State, _Extra) -> 
+    {ok, State}.
 
 terminate(_Reason, _State) ->
 	ok.

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -12,8 +12,8 @@
 
 -export([
 	start_link/0,
-	get_any_from_cluster/1,
-	get_any/0,
+	get_any_client/1,
+	get_any_client/0,
     add_clients/1,
     add_clients/2,
     add_clients_to_cluster/2,
@@ -47,7 +47,7 @@ add_clients_to_cluster(Key, ClientKeys, Opts0) ->
 			{Inet, Opts0}
 	end, ClientKeys)).
 
-get_any_from_cluster(Key) ->
+get_any_client(Key) ->
 	case ets:lookup(cqerl_clusters, Key) of
 		[] -> {error, cluster_not_configured};
 		Nodes ->
@@ -55,8 +55,8 @@ get_any_from_cluster(Key) ->
 			cqerl_hash:get_client(Table#cluster_table.client_key)
 	end.
 
-get_any() ->
-	get_any_from_cluster(?PRIMARY_CLUSTER).
+get_any_client() ->
+	get_any_client(?PRIMARY_CLUSTER).
 
 init(_) ->
     ets:new(cqerl_clusters, [named_table, {read_concurrency, true}, protected, 

--- a/src/cqerl_sup.erl
+++ b/src/cqerl_sup.erl
@@ -40,5 +40,6 @@ init(hash) ->
       ?CHILD(cqerl_batch_sup, supervisor),
       ?CHILD(cqerl_processor_sup, supervisor),
       ?CHILD(cqerl_client_sup, supervisor),
-      ?CHILD(cqerl_hash, worker)
+      ?CHILD(cqerl_hash, worker),
+      ?CHILD(cqerl_cluster, worker)
     ]}}.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1,0 +1,242 @@
+%% common_test suite for cluster
+
+-module (cluster_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include("cqerl.hrl").
+
+
+-import(test_helper, [
+                    %  maybe_get_client/1,
+                      get_client/1
+                     ]).
+
+-compile(export_all).
+
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%%
+%% Info = [tuple()]
+%%   List of key/value pairs.
+%%
+%% Description: Returns list of tuples to set default properties
+%%              for the suite.
+%%
+%% Note: The suite/0 function is only meant to be used to return
+%% default data values, not perform any other operations.
+%%--------------------------------------------------------------------
+suite() ->
+  [{timetrap, {seconds, 30}} | test_helper:requirements()].
+
+%%--------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%%
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%%   The name of the group.
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%%   Group properties that may be combined.
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%%   The name of a test case.
+%% Shuffle = shuffle | {shuffle,Seed}
+%%   To get cases executed in random order.
+%% Seed = {integer(),integer(),integer()}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%%   To get execution of cases repeated.
+%% N = integer() | forever
+%%
+%% Description: Returns a list of test case group definitions.
+%%--------------------------------------------------------------------
+
+groups() ->
+    [
+     {single, [sequence], [test_get_clients]},
+     {multi, [sequence], [test_get_clients_from_cluster]}
+    ].
+
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases
+%%
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%%   Name of a test case group.
+%% TestCase = atom()
+%%   Name of a test case.
+%%
+%% Description: Returns the list of groups and test cases that
+%%              are to be executed.
+%%
+%%      NB: By default, we export all 1-arity user defined functions
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     {group, single},
+     {group, multi}
+    ].
+
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the suite.
+%%
+%% Description: Initialization before the suite.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    test_helper:set_mode(pooler, Config),
+
+    Config0 = test_helper:standard_setup("test_keyspace_1", Config),
+    test_helper:create_keyspace(<<"test_keyspace_1">>, Config0),
+
+    Config1 = test_helper:standard_setup("test_keyspace_2", Config0),
+    test_helper:create_keyspace(<<"test_keyspace_2">>, Config1),
+
+    Client = get_client(Config0),
+    {ok, #cql_schema_changed{change_type=created, keyspace = <<"test_keyspace_1">>,
+                             name = <<"entries1">>}} =
+    cqerl:run_query(Client, "CREATE TABLE entries1 (id int PRIMARY KEY, name text);"),
+    cqerl:close_client(Client),
+
+    test_helper:set_mode(hash, Config1).
+
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Cleanup after the suite.
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%% Reason = term()
+%%   The reason for skipping all test cases and subgroups in the group.
+%%
+%% Description: Initialization before each test case group.
+%%--------------------------------------------------------------------
+
+
+init_per_group(single, Config) ->
+    test_helper:set_mode(hash, Config),
+
+    Host = proplists:get_value(host, Config),
+    SSL = proplists:get_value(prepared_ssl, Config),
+    Auth = proplists:get_value(auth, Config, undefined),
+    Keyspace = proplists:get_value(keyspace, Config),
+    ProtocolVersion = proplists:get_value(protocol_version, Config),
+    
+    Opts = [{ssl, SSL}, {auth, Auth}, {keyspace, Keyspace},
+            {protocol_version, ProtocolVersion} ],
+
+    cqerl_cluster:add_nodes([ Host ], Opts);
+
+init_per_group(multi, Config) ->
+    test_helper:set_mode(hash, Config),
+
+    Host = proplists:get_value(host, Config),
+    SSL = proplists:get_value(prepared_ssl, Config),
+    Auth = proplists:get_value(auth, Config, undefined),
+    ProtocolVersion = proplists:get_value(protocol_version, Config),
+    
+    Opts = [{ssl, SSL}, {auth, Auth}, {protocol_version, ProtocolVersion} ],
+
+    cqerl_cluster:add_nodes(cluster1, [ Host ], [{keyspace, test_keyspace_1} | Opts]),
+    cqerl_cluster:add_nodes(cluster2, [ Host ], [{keyspace, test_keyspace_2} | Opts]);
+
+init_per_group(_, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%               void() | {save_config,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%%
+%% Description: Cleanup after each test case group.
+%%--------------------------------------------------------------------
+end_per_group(_group, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the test case.
+%%
+%% Description: Initialization before each test case.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config0) ->
+%%               void() | {save_config,Config1} | {fail,Reason}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for failing the test case.
+%%
+%% Description: Cleanup after each test case.
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+test_get_clients(_Config) ->
+    {ok, {Pid, Ref1}} = cqerl:get_client(),
+    {ok, {Pid, Ref2}} = cqerl:get_client(),
+    if
+      Ref1 == Ref2 -> 
+        ct:fail("Two subsequent calls to get_client/0 generated exactly the same client handle", []);
+      true ->
+        ok
+    end,
+    ok.
+
+test_get_clients_from_cluster(_Config) ->
+    {ok, {Pid1, Ref1}} = cqerl:get_client(cluster1),
+    {ok, {Pid1, Ref2}} = cqerl:get_client(cluster1),
+    {ok, {Pid2, Ref3}} = cqerl:get_client(cluster2),
+    {ok, {Pid2, Ref4}} = cqerl:get_client(cluster2),
+    if
+      Ref1 == Ref2; Ref3 == Ref4 -> 
+        ct:fail("Two subsequent calls to get_client/1 for the same cluster generated exactly the same client handle", []);
+
+      Pid1 == Pid2 -> 
+        ct:fail("Two calls to get_client/1 for different cluster generated exactly the same connection pid", []);
+
+      true ->
+        ok
+    end,
+    ok.


### PR DESCRIPTION
##### This is a work-in-progress PR for version 1.0

Suggested changes:

1. Make `hash` mode the default (addresses #49), and still support `pooler` mode when set explicitly
2. Support multiple configured C* clusters (addresses #59), with simpler old-style "single-cluster" mode seamlessly supported
3. Discuss if we can bake in token-aware policy (addresses #48)

---

##### Cluster support

The information about the members of a cluster is kept in a protected ets table, readable from the user's process, so no bottleneck is introduced in this mechanism, just one more hop to a ETS table.

```erlang

%% sys.config

{cqerl, [ {cassandra_clusters, #{
    change_log => [
      { {"123.123.123.123", 9042}, [{keyspace, change_log}]},
      { {"124.124.124.124", 9042}, [{keyspace, change_log}]}
    ]
}]}

> cqerl_cluster:get_any_from_cluster(change_log).
{ok, {<0.78.0>,#Ref<0.0.8.367>}}

> cqerl_cluster:add_clients_to_cluster(messages, [
    { {"123.123.123.123", 9042}, [{keyspace, messages}]},
    { {"124.124.124.124", 9042}, [{keyspace, messages}]}
]).
ok

> cqerl_cluster:get_any_from_cluster(messages).
{ok, {<0.73.0>,#Ref<0.0.8.366>}}
```

##### Simple clusters

```erlang
%% sys.config

{cqerl, [ {cassandra_nodes, [
      { {"123.123.123.123", 9042}, [{keyspace, change_log}]}
]]}

> cqerl_cluster:add_clients([
    { {"124.124.124.124", 9042}, [{keyspace, change_log}]}
]).
ok

> cqerl_cluster:get_any().
{ok, {<0.73.0>,#Ref<0.0.8.366>}}
```