### PR TITLE
Prevent authentication credentials from being logged

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -137,14 +137,14 @@ get_client(ClusterKey) when is_atom(ClusterKey) ->
     cqerl_cluster:get_any_client(ClusterKey);
 
 get_client({}) ->
-    cqerl_hash:get_client({prepare_node_info({?LOCALHOST, ?DEFAULT_PORT}), []});
+    cqerl_hash:get_client(prepare_node_info({?LOCALHOST, ?DEFAULT_PORT}), []);
 
 get_client(Spec) ->
-    cqerl_hash:get_client({prepare_node_info(Spec), []}).
+    cqerl_hash:get_client(prepare_node_info(Spec), []).
 
 -spec get_client(Inet :: inet(), Opts :: list(tuple() | atom())) -> {ok, client()} | {error, term()}.
 get_client(Spec, Opts) ->
-    cqerl_hash:get_client({prepare_node_info(Spec), Opts}).
+    cqerl_hash:get_client(prepare_node_info(Spec), Opts).
 
 
 
@@ -508,12 +508,13 @@ new_pool(NodeKey={Ip, Port, Keyspace}, LocalOpts, GlobalOpts, State=#cqerl_state
                      {max_count,       OptGetter(pool_max_size)},
                      {cull_interval,   OptGetter(pool_cull_interval)},
                      {max_age,         {Amount/2, Unit}},
-                     {start_mfa,       {cqerl_client, start_link, [{Ip, Port},
-                                           [  {auth, OptGetter(auth)},
-                                              {ssl, OptGetter(ssl)},
+                     {start_mfa,       {cqerl_client, start_link, [
+                                           {Ip, Port},
+                                           [  {ssl, OptGetter(ssl)},
                                               {sleep_duration, {Amount/2, Unit}},
-                                              {keyspace, Keyspace},
-                                              {protocol_version, OptGetter(protocol_version)} ]
+                                              {keyspace, Keyspace}
+                                           ],
+                                           OptGetter
                                         ]}
                      }
                    ]),

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -130,7 +130,7 @@ batch_ready({ClientPid, Call}, QueryBatch) ->
 make_key(Node, Opts) ->
     SafeOpts =
     case lists:keytake(auth, 1, Opts) of
-        {value, {auth, Auth}, Opts1} -> [{auth, erlang:phash2(Auth)} | Opts1];
+        {value, {auth, Auth}, Opts1} -> [{auth_hash, erlang:phash2(Auth)} | Opts1];
         false -> Opts
     end,
     NormalisedOpts = normalise_keyspace(SafeOpts),

--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -8,10 +8,9 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 
--export([start_link/2, start_link/3, new_user/2, remove_user/1,
+-export([start_link/3, start_link/4, new_user/2, remove_user/1,
          run_query/2, query_async/2, fetch_more/1, fetch_more_async/1,
-         prepare_query/2,
-         batch_ready/2]).
+         prepare_query/2, batch_ready/2, make_key/2]).
 
 %% ------------------------------------------------------------------
 %% gen_fsm Function Exports
@@ -70,11 +69,11 @@ end).
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
-start_link(Inet, Opts) ->
-    gen_fsm:start_link(?MODULE, [Inet, Opts, undefined], []).
+start_link(Inet, Opts, OptGetter) ->
+    gen_fsm:start_link(?MODULE, [Inet, Opts, OptGetter, undefined], []).
 
-start_link(Inet, Opts, Key) ->
-    gen_fsm:start_link(?MODULE, [Inet, Opts, Key], []).
+start_link(Inet, Opts, OptGetter, Key) ->
+    gen_fsm:start_link(?MODULE, [Inet, Opts, OptGetter, Key], []).
 
 new_user(Pid, From) ->
     case cqerl_app:mode() of
@@ -128,23 +127,39 @@ prepare_query(ClientPid, Query) ->
 batch_ready({ClientPid, Call}, QueryBatch) ->
     gen_fsm:send_event(ClientPid, {batch_ready, Call, QueryBatch}).
 
+make_key(Node, Opts) ->
+    SafeOpts =
+    case lists:keytake(auth, 1, Opts) of
+        {value, {auth, Auth}, Opts1} -> [{auth, erlang:phash2(Auth)} | Opts1];
+        false -> Opts
+    end,
+    NormalisedOpts = normalise_keyspace(SafeOpts),
+    {Node, lists:usort(NormalisedOpts)}.
+
+normalise_keyspace(Opts) ->
+    KS = proplists:get_value(keyspace, Opts),
+    [{keyspace, normalise_to_atom(KS)} | proplists:delete(keyspace, Opts)].
+
+normalise_to_atom(KS) when is_list(KS) -> list_to_atom(KS);
+normalise_to_atom(KS) when is_binary(KS) -> binary_to_atom(KS, latin1);
+normalise_to_atom(KS) when is_atom(KS) -> KS.
+
 %% ------------------------------------------------------------------
 %% gen_fsm Function Definitions
 %% ------------------------------------------------------------------
 
-init([Inet, Opts, Key]) ->
+init([Inet, Opts, OptGetter, Key]) ->
     case create_socket(Inet, Opts) of
         {ok, Socket, Transport} ->
-            {auth, {AuthHandler, AuthArgs}} = proplists:lookup(auth, Opts),
-            cqerl:put_protocol_version(proplists:get_value(protocol_version, Opts, cqerl:get_protocol_version())),
+            {AuthHandler, AuthArgs} = OptGetter(auth),
+            cqerl:put_protocol_version(OptGetter(protocol_version)),
             {ok, OptionsFrame} = cqerl_protocol:options_frame(#cqerl_frame{}),
-            put(uuidstate, uuid:new(self())),
             State = #client_state{
                 socket=Socket, trans=Transport, inet=Inet,
                 authmod=AuthHandler, authargs=AuthArgs,
                 users=[],
                 sleep=get_sleep_duration(Opts),
-                keyspace=proplists:get_value(keyspace, Opts),
+                keyspace=normalise_to_atom(proplists:get_value(keyspace, Opts)),
                 key=Key,
                 mode=cqerl_app:mode()
             },


### PR DESCRIPTION
@toland noticed that, as a side-effect of passing credentials into client processes via a supervisor start, they ended up being logged by the supervisor. Obviously, generally speaking, logging passwords is Bad.
Turned out the fix was a bit complicated, since auth data was actually passed through in two parameters - the `Opts` and the `Key`.
After a few different attempts, I fixed the `Opts` issue by passing through the `OptsGetter` function and calling that from within the client. Even though the fun still effectively encapsulates the data, it doesn't show up in the log.
The key was a bit more fiddly since it's passed around and used interchangeably with the `{Node, Opts}` tuple it actually is. That meant that simply taking the auth data out of the Key would potentially break other bits, as well as precluding us from allowing one application to use multiple different credentials on one server (which, while unlikely, is permissible and no doubt if it's not allowed someone will want to do it). So what I ended up doing is, as much as I could, distinguishing in code between the Node/Opts data and the Key. The Key is now extra-noramlised, so that even if the order of opts are shuffled by the user, they'll still generate the same key. Additionally, to solve the original problem, the `auth` field of the key has been replaced with `auth_hash` which is a hash of the actual auth term (since in the key it's only used to identify common values, not to actually do any authorisation).