### PR TITLE
Add default null for encode {udt, Types}

### DIFF
--- a/src/cqerl_datatypes.erl
+++ b/src/cqerl_datatypes.erl
@@ -448,7 +448,7 @@ encode_data({{tuple, Types}, List}, _Query) when is_list(List) ->
 
 encode_data({{udt, Types}, Values}, _Query) when is_list(Values) ->
     GetValueBinary = fun({Name, Type}) ->
-        Value = proplists:get_value(binary_to_atom(Name, utf8), Values),
+        Value = proplists:get_value(binary_to_atom(Name, utf8), Values, null),
         Bin = encode_data({Type, Value}, _Query),
         {ok, Bytes} = encode_bytes(Bin),
         Bytes


### PR DESCRIPTION
It allows to let unnecessary fields be empty when binding a user define type column