### PR TITLE
Fix case_clause bug when a prepare gets dequeued

### DIFF
--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -562,6 +562,10 @@ dequeue_query(State0=#client_state{queued=Queue0}) ->
             State1 = process_outgoing_query(Call, Batch, State0),
             {true, State1#client_state{queued=Queue1}};
 
+        {{value, {prepare, Query}}, Queue1} when is_binary(Query) ->
+            State1 = process_outgoing_query(prepare, Query, State0),
+            {true, State1#client_state{queued=Queue1}};
+
         {{value, {Call, Item}}, Queue1} ->
             case Item of
                 Query=#cql_query{} -> ok;


### PR DESCRIPTION
@matehat here's another one we had to add to our fork a while back due to this error:

```erlang
{failed,
    {'EXIT',
        {badmatch,
            {error,
                {{case_clause,
                     <<"UPDATE ...my cql query here...">>},
                 [{cqerl_client,dequeue_query,1,
                      [{file,"src/cqerl_client.erl"},{line,566}]},
                  {cqerl_client,release_stream_id,2,
                      [{file,"src/cqerl_client.erl"},{line,605}]},
                  {cqerl_client,handle_info,3,
                      [{file,"src/cqerl_client.erl"},{line,418}]},
                  {gen_fsm,handle_msg,7,[{file,"gen_fsm.erl"},{line,518}]},
                  {proc_lib,init_p_do_apply,3,
                      [{file,"proc_lib.erl"},{line,240}]}]}}}}}
```