### PR TITLE
Change prepared query cache to be per-node rather than per-client

### DIFF
--- a/include/cqerl_protocol.hrl
+++ b/include/cqerl_protocol.hrl
@@ -96,7 +96,7 @@
 }).
 
 -record(cqerl_cached_query, {
-    key :: {pid(), binary() | '_'},
+    key :: {cqerl:cqerl_node(), binary() | '_'},
     query_ref = <<>> :: binary() | '_',
     params_metadata :: #cqerl_result_metadata{} | '_',
     result_metadata :: #cqerl_result_metadata{} | '_'

--- a/src/cqerl_batch_sup.erl
+++ b/src/cqerl_batch_sup.erl
@@ -6,7 +6,7 @@
 -export([start_link/0]).
 
 %% Supervisor callbacks
--export([init/1, new_batch_coordinator/2]).
+-export([init/1, new_batch_coordinator/3]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I), {I, {I, start_link, []}, transient, 5000, worker, [I]}).
@@ -18,8 +18,8 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-new_batch_coordinator(Call, Batch) ->
-    {ok, _Pid} = supervisor:start_child(?MODULE, [{self(), Call}, Batch]),
+new_batch_coordinator(Call, Node, Batch) ->
+    {ok, _Pid} = supervisor:start_child(?MODULE, [{self(), Call}, Node, Batch]),
     ok.
 
 %% ===================================================================

--- a/src/cqerl_processor_sup.erl
+++ b/src/cqerl_processor_sup.erl
@@ -1,12 +1,14 @@
 -module(cqerl_processor_sup).
 
+-include("cqerl_protocol.hrl").
+
 -behaviour(supervisor).
 
 %% API
 -export([start_link/0]).
 
 %% Supervisor callbacks
--export([init/1, new_processor/3]).
+-export([init/1, new_processor/4]).
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I), {I, {I, start_link, []}, transient, 5000, worker, [I]}).
@@ -18,8 +20,13 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-new_processor(UserQuery, Msg, ProtocolVersion) ->
-    {ok, _Pid} = supervisor:start_child(?MODULE, [self(), UserQuery, Msg, ProtocolVersion]),
+-spec new_processor(Node :: cqerl:cqerl_node(),
+                    UserQuery :: term(),
+                    Msg :: cqerl_processor:processor_message(),
+                    ProtocolVersion :: non_neg_integer()) -> ok.
+new_processor(Node, UserQuery, Msg, ProtocolVersion) ->
+    {ok, _Pid} = supervisor:start_child(
+                   ?MODULE, [self(), Node, UserQuery, Msg, ProtocolVersion]),
     ok.
 
 %% ===================================================================


### PR DESCRIPTION
It turns out that C* prepared queries are cached per node and not
discarded when the requesting connection is dropped (but rather only
when the node is restarted or they are cycled out of the cache). That
means we can shrink the size of our prepared query cache so that it only
holds at most one copy of each query per node (with the side benefit of
also only needing to prepare each query once per node).

This also has the benefit of working around the C* bug described at
https://issues.apache.org/jira/browse/CASSANDRA-10786, since we only
cache the query once and remove that instance from the cache if we get
'unprepared'.