### PR TITLE
Observed memory leak problem of re2 NIF library

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,5 @@
   {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.2"}}},
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
-  {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
-  {re2, ".*", {git, "https://github.com/matehat/re2.git"}}
+  {pooler, ".*", {git, "https://github.com/guitarmind/pooler.git"}}
 ]}.

--- a/src/cqerl.app.src
+++ b/src/cqerl.app.src
@@ -2,7 +2,7 @@
              [{description,"CQErl client for Cassandra"},
               {vsn,"1.0.1"},
               {registered,[cqerl,cqerl_sup,cqerl_cache,cqerl_batch_sup]},
-              {applications,[kernel,stdlib,ssl,pooler,re2,semver,snappy,lz4,
+              {applications,[kernel,stdlib,ssl,pooler,semver,snappy,lz4,
                              uuid]},
               {mod,{cqerl_app,[]}},
               {env,[]}]}.

--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -677,23 +677,23 @@ prepare_node_info(Addr) when is_atom(Addr);
     prepare_node_info({Addr, ?DEFAULT_PORT});
 
 prepare_node_info(Addr) when is_binary(Addr) ->
-    case re2:match(Addr, ?IPV4_RE) of
-        {match, [_, IP, <<>>]} ->
+    case re:split(Addr, ?IPV4_RE) of
+        [_, IP, <<>>, _] when length(IP) > 0 ->
             prepare_node_info({binary_to_list(IP), ?DEFAULT_PORT});
-        {match, [_, IP, Port]} ->
+        [_, IP, Port, _] when length(IP) > 0 andalso length(Port) > 0 ->
             {PortInt, []} = string:to_integer(binary_to_list(Port)),
             prepare_node_info({binary_to_list(IP), PortInt});
-        nomatch ->
+        _ ->
             prepare_node_info({binary_to_list(Addr), ?DEFAULT_PORT})
     end;
 prepare_node_info(Addr) when is_list(Addr) ->
-    case re2:match(Addr, ?IPV4_RE) of
-        {match, [_, IP, <<>>]} ->
+    case re:split(Addr, ?IPV4_RE) of
+        [_, IP, <<>>, _] when length(IP) > 0 ->
             prepare_node_info({binary_to_list(IP), ?DEFAULT_PORT});
-        {match, [_, IP, Port]} ->
+         [_, IP, Port, _] when length(IP) > 0 andalso length(Port) > 0 ->
             {PortInt, []} = string:to_integer(binary_to_list(Port)),
             prepare_node_info({binary_to_list(IP), PortInt});
-        nomatch ->
+        _ ->
             prepare_node_info({Addr, ?DEFAULT_PORT})
     end.
 

--- a/src/cqerl_cache.erl
+++ b/src/cqerl_cache.erl
@@ -55,11 +55,11 @@ lookup(_ClientPid, #cql_query{reusable=false}) ->
 lookup(ClientPid, Query = #cql_query{statement=Statement}) ->
     case get(?NAMED_BINDINGS_RE_KEY) of
         undefined ->
-            {ok, RE} = re2:compile(?NAMED_BINDINGS_RE),
+            {ok, RE} = re:compile(?NAMED_BINDINGS_RE),
             put(?NAMED_BINDINGS_RE_KEY, RE);
         RE -> ok
     end,
-    case re2:match(Statement, RE) of
+    case re:run(Statement, RE) of
         nomatch ->
             lookup(ClientPid, Query#cql_query{reusable=false, named=false});
 


### PR DESCRIPTION
Hi,

Thanks for the great implementation of Cassandra client! I'm using cqerl for a project to create a timeseries storage service on top of Cassandra, during some stress tests with 100-200 concurrent requests with mixed reads/writes, I found that there is a serious memory leak issue in current master version of cqerl, which is reproducible in different OS platform.

**Tested Environments**

```
- Ubuntu 14.04 LTS 64-bit (a VM of 2 vCPU and 4GB RAM)
- Alpine Linux 3.4 64-bit (a Docker container of 1 vCPU and 1GB RAM)
```

**Proof of leak**

I used a live memory leak tracking tool called [memleax](https://github.com/WuBingzheng/memleax), and found that all leaks refer to the same line of code (`re2_match()+825  c_src/re2_nif.cpp:282`) in the re2 NIF dependency used in cqerl:

```
CallStack[15]: may-leak=199 (7960 bytes)
    expired=199 (7960 bytes), free_expired=0 (0 bytes)
    alloc=292 (11680 bytes), free=0 (0 bytes)
    freed memory live time: min=0 max=0 average=0
    un-freed memory live time: max=25
    0x00007fafd21a8750  libc-2.19.so  malloc()+0  /build/eglibc-3GlaMS/eglibc-2.19/malloc/hooks.c:77
    0x00007faf9e3afdad  libstdc++.so  _Znwm()+29
    0x00007faf9e676972  re2_nif.so  _ZN3re26Regexp17ConcatOrAlternateENS_8RegexpOp()+642
    0x00007faf9e69a62a  re2_nif.so  _ZN3re26Regexp10ParseState10DoCollapseENS_8Reg()+394
    0x00007faf9e69a748  re2_nif.so  _ZN3re26Regexp10ParseState13DoVerticalBarEv()+24
    0x00007faf9e69a7f9  re2_nif.so  _ZN3re26Regexp10ParseState13DoAlternationEv()+9
    0x00007faf9e69a829  re2_nif.so  _ZN3re26Regexp10ParseState8DoFinishEv()+9
    0x00007faf9e69d140  re2_nif.so  _ZN3re26Regexp5ParseERKNS_11StringPieceENS0_10()+352
    0x00007faf9e66b9a7  re2_nif.so  _ZN3re23RE24InitERKNS_11StringPieceERKNS0_7Opt()+455
    0x00007faf9e66ce72  re2_nif.so  _ZN3re23RE2C1ERKNS_11StringPieceERKNS0_7Option()+98
    0x00007faf9e669ed9  re2_nif.so  re2_match()+825  c_src/re2_nif.cpp:282
    0x0000000000436370  beam.smp  process_main()+16624
    0x00000000004b4fdf  beam.smp
    0x00000000005b92ab  beam.smp
    0x00007fafd26fb182  libpthread-2.19.so  start_thread()+194  /build/eglibc-3GlaMS/eglibc-2.19/nptl/pthread_create.c:312
    0x00007fafd222047d  libc-2.19.so  clone()+109  ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
```

![mem_usage_comparison](https://cloud.githubusercontent.com/assets/5718858/18415244/240c92f0-781e-11e6-82c8-69131cd399fb.png)

![live_erlang_vm](https://cloud.githubusercontent.com/assets/5718858/18415245/26adb1e2-781e-11e6-9746-0b686adf2381.png)

Please check attachments for full details.

I changed the implementation to replace re2 with built-in Erlang re library, and the memory leaking issue no longer exists. Understood that the original thought of using re2 is to have a more linear worst case ([#49](https://github.com/matehat/cqerl/issues/49)) but not sure if it really provides significant performance improvement in current usage of regular expression matching in cqerl.

Suggest to change back to re library before we report and fix the issue to the upstream of re2 NIF library? Thanks!

[mem_leak_re2_20160906.txt](https://github.com/matehat/cqerl/files/465765/mem_leak_re2_20160906.txt)
