### PR TITLE
Update re2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
   {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
-  {re2, ".*", {git, "https://github.com/matehat/re2.git"}}
+  {re2, ".*", {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.1"}}}
 ]}.


### PR DESCRIPTION
After that change, I was able to compile and use cqerl client again. I'm not experienced enough to tell if the change has any further implications. 

### Changes

- Update re2 dependency to point to https://github.com/tuncer/re2 tag:v1.7.1

### Reference 

Fixes #125 