### PR TITLE
Add timeout to add_nodes/1,2,3 gen_server calls

### DIFF
--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -21,7 +21,11 @@
     add_nodes/3
 ]).
 
--define (PRIMARY_CLUSTER, '$primary_cluster').
+-define(PRIMARY_CLUSTER, '$primary_cluster').
+-define(ADD_NODES_TIMEOUT, case application:get_env(cqerl, add_nodes_timeout) of
+    undefined -> 30000;
+    {ok, Val} -> Val
+end).
 
 -record(cluster_table, {
           key :: cqerl_hash:key(),
@@ -32,13 +36,13 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 add_nodes(ClientKeys) ->
-    gen_server:call(?MODULE, {add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}).
+    gen_server:call(?MODULE, {add_to_cluster, ?PRIMARY_CLUSTER, ClientKeys}, ?ADD_NODES_TIMEOUT).
 
 add_nodes(ClientKeys, Opts) when is_list(ClientKeys) ->
     add_nodes(?PRIMARY_CLUSTER, ClientKeys, Opts);
 
 add_nodes(Key, ClientKeys) when is_atom(Key) ->
-    gen_server:call(?MODULE, {add_to_cluster, Key, ClientKeys}).
+    gen_server:call(?MODULE, {add_to_cluster, Key, ClientKeys}, ?ADD_NODES_TIMEOUT).
 
 add_nodes(Key, ClientKeys, Opts0) ->
 	add_nodes(Key, lists:map(fun


### PR DESCRIPTION
add_nodes/1,2,3 was previously async, but were changed to use gen_server:call
instead to prevent a race condition (#111). That change did however introduce
the possibility of gen_server timing out before the add_to_cluster handler had
completed.

This commit introduces an application env variable that makes it possible to
specify the timeout, and sets it to 30 seconds if not specified.