### PR TITLE
Use more recent snappy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps, [
-  {snappy, ".*", {git, "https://github.com/fdmanana/snappy-erlang-nif.git", "c4cd1bb"}},
+  {snappy, ".*", {git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b861"}},
   {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.2"}}},
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},


### PR DESCRIPTION
This PR updates `rebar.config` with new `snappy` version, that includes fix which makes Mac users' life easier.