### PR TITLE
Update lz4 to new release 0.2.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps, [
   {snappy, ".*", {git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b861"}},
-  {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.2"}}},
+  {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.4"}}},
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
   {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},


### PR DESCRIPTION
Currently, cqex fails on Elixir 1.4.x/OTP 19 due to an outdated dependency on lz4. This PR bumps lz4 to make everything work again.