### PR TITLE
Bump re2 version to 1.7.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
   {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
-  {re2, ".*", {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.2"}}}
+  {re2, ".*", {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.5"}}}
 ]}.


### PR DESCRIPTION
This version tries to fetch dependency from Github, if possible. It is a great help for developers in China, where Google is blocked.