### PR TITLE
Update pooler to 1.5.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,6 @@
   {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.2"}}},
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
-  {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
+  {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.2"}}},
   {re2, ".*", {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.2"}}}
 ]}.


### PR DESCRIPTION
When trying to compile an empty Elixir project with only cqerl as dependency and using Erlang/OTP 20, I get this

```
➜  test iex -S mix
Erlang/OTP 20 [erts-9.0] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]
===> Compiling pooler
===> Compiling src/pooler.erl failed
src/pooler.erl:60: export_all flag enabled - all functions will be exported
** (Mix) Could not compile dependency :pooler, "/home/rbino/.mix/rebar3 bare compile --paths "/tmp/test/_build/dev/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile pooler", update it with "mix deps.update pooler" or clean it with "mix deps.clean pooler"
```

Bumping `pooler` to 1.5.2 fixes this problem.