### PR TITLE
Fix expected message format for the preparation_failed notification

### DIFF
--- a/src/cqerl_batch.erl
+++ b/src/cqerl_batch.erl
@@ -36,7 +36,7 @@ loop(Call, Batch=#cql_query_batch{queries=QueryStates}, Debug, Parent) ->
                     end, Batch#cql_query_batch.queries),
                     loop(Call, Batch#cql_query_batch{queries=NewQueries}, Debug, Parent);
 
-                {preparation_failed, Reason} ->
+                {preparation_failed, _Key, Reason} ->
                     %% TODO: The function cqerl_client:batch_failed/3 doesn't
                     %% exist. If this call is important, the function will need
                     %% to be implemented. Otherwise, we should remove this call.


### PR DESCRIPTION
In case of a failed preparation for a batch, the message notifying about this issue would be lost, because the tuple contains 3 elements, not 2.