### PR TITLE
OTP 20 function call changes

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -313,7 +313,7 @@ start_link() ->
 
 
 init([]) ->
-    random:seed(?SEED),
+    rand:seed(?SEED),
     process_flag(trap_exit, true),
     BaseState = #cqerl_state{clients = ets:new(clients, [set, private, {keypos, #cql_client.pid}]),
         client_stats = [],
@@ -335,7 +335,7 @@ handle_call(Req={get_client, Node, Opts}, From,
     NodeKey = if
         is_atom(Node) ->
             {ok, Nodes} = orddict:find(Node, NamedNodes),
-            lists:nth(random:uniform(length(Nodes)), Nodes);
+            lists:nth(rand:uniform(length(Nodes)), Nodes);
         true ->
             node_key(Node, {Opts, GlobalOpts})
     end,
@@ -619,7 +619,7 @@ make_option_getter(Local, Global) ->
 select_client(Clients, MatchClient = #cql_client{node=Node}, User, _State) ->
     case ets:match_object(Clients, MatchClient) of
         AvailableClients when length(AvailableClients) > 0 ->
-            RandIdx = random:uniform(length(AvailableClients)),
+            RandIdx = rand:uniform(length(AvailableClients)),
             #cql_client{pid=Pid, node=NodeKey} = lists:nth(RandIdx, AvailableClients),
             case cqerl_client:new_user(Pid, User) of
                 ok -> {existing, Pid, NodeKey};

--- a/src/cqerl_cluster.erl
+++ b/src/cqerl_cluster.erl
@@ -57,7 +57,7 @@ get_any_client(Key) ->
 		[] -> {error, cluster_not_configured};
 		Nodes ->
             #cluster_table{client_key = {Node, Opts}} =
-                           lists:nth(random:uniform(length(Nodes)), Nodes),
+                           lists:nth(rand:uniform(length(Nodes)), Nodes),
 			cqerl_hash:get_client(Node, Opts)
 	end.
 

--- a/test/cqerl_datatypes_tests.erl
+++ b/test/cqerl_datatypes_tests.erl
@@ -60,7 +60,7 @@ long_string_test() ->
 
 bytes_test() ->
   % Test that encoding a proper byte sequence returns a properly encoded binary
-  Bytes1 = crypto:rand_bytes(100000),
+  Bytes1 = crypto:strong_rand_bytes(100000),
   {ok, EncodedBytes1} = cqerl_datatypes:encode_bytes(Bytes1),
   case size(Bytes1) + ?INT_LENGTH of
     Size2 when Size2 == size(EncodedBytes1) -> ok
@@ -75,7 +75,7 @@ bytes_test() ->
 short_bytes_test() ->
   
   % Test that encoding a proper byte sequence returns a properly encoded binary
-  Bytes1 = crypto:rand_bytes(5000),
+  Bytes1 = crypto:strong_rand_bytes(5000),
   {ok, EncodedBytes1} = cqerl_datatypes:encode_short_bytes(Bytes1),
   case size(Bytes1) + ?SHORT_LENGTH of
     Size2 when Size2 == size(EncodedBytes1) -> ok


### PR DESCRIPTION
- replace `crypto:rand_bytes/1`, which is gone in OTP 20 (it's used in the eunit tests)
- replace `random:uniform/1`, which is deprecated in OTP 20

The remaining warnings from OTP 20 that I see are about upgrading `cqerl_client` from `gen_fsm` to `gen_statem`.