### PR TITLE
Increase cqerl_client_sup's restart intensity

### DIFF
--- a/src/cqerl_client_sup.erl
+++ b/src/cqerl_client_sup.erl
@@ -43,7 +43,7 @@ init([key, Key = {Node, _Opts}, FullOpts, OptGetter, ChildCount]) ->
      {
       #{
        strategy => one_for_one,
-       intensity => 5,
+       intensity => ChildCount + 5,
        period => 10
       },
       [


### PR DESCRIPTION
...to be at least as big as connection pool in case of longer inactivity of 5 or more connections.

The issue here was, that Cassandra (by default) closes connection after 1 minute of inactivity. If we have at least 5 inactive connections in pool (which is quite easy, since by default pool has 20 connections), they would close very likely all at once, therefore tripping supervisor's `restart intensity`. This in turn would close the entire pool of connection even if some of them are in the middle of query. Not only that, but the pool wouldn't restart after that, at least not until next query.  