### PR TITLE
Handle empty_dataset also in head/2

### DIFF
--- a/src/cqerl.erl
+++ b/src/cqerl.erl
@@ -267,6 +267,7 @@ head(#cql_result{dataset=[]}) -> empty_dataset;
 head(Result) ->
     head(Result, get_options_list()).
 
+head(#cql_result{dataset=[]}, _Opts) -> empty_dataset;
 head(#cql_result{dataset=[Row|_Rest], columns=ColumnSpecs}, Opts) ->
     cqerl_protocol:decode_row(Row, ColumnSpecs, Opts).
 


### PR DESCRIPTION
Avoid crashing when calling `head/2` with some options on an empty result