### PR TITLE
Changed client so that it handles ssl_closed events

### DIFF
--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -332,6 +332,13 @@ handle_info({ tcp_closed, _Socket }, live, State = #client_state{ queries = Quer
     [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
     {stop, connection_closed, State};
 
+handle_info({ ssl_closed, _Socket }, starting, State) ->
+    stop_during_startup({error, connection_closed}, State);
+
+handle_info({ ssl_closed, _Socket }, live, State = #client_state{ queries = Queries }) ->
+    [ respond_to_user(Call, {error, connection_closed}) || {_, {Call, _}} <- Queries ],
+    {stop, connection_closed, State};
+
 
 handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ socket=Socket, trans=Transport, delayed=Delayed0 }) ->
     Resp = case cqerl_protocol:response_frame(#cqerl_frame{}, << Delayed0/binary, BinaryMsg/binary >>) of


### PR DESCRIPTION
When using TLS/SSL the client does not handle the 'ssl_closed' event. When the connection to the server is broken (for instance, due to the server restarting) the client ends up in a kind of zombie state. The clients never fail, are never restarted, and all queries end up hitting the FSM timeout.